### PR TITLE
[security] jsoup 1.17.2 → 1.18.3 (CVE-2024-32104)

### DIFF
--- a/EgovBoard/pom.xml
+++ b/EgovBoard/pom.xml
@@ -157,7 +157,7 @@
         <dependency>
             <groupId>org.jsoup</groupId>
             <artifactId>jsoup</artifactId>
-            <version>1.17.2</version>
+            <version>1.18.3</version>
         </dependency>
         <!-- CVE-2024-47072: spring-cloud-starter-netflix-eureka-client에서 주입되는 configuration 1.1 취약점 보완용 직접 주입 -->
         <dependency>


### PR DESCRIPTION
## 변경 사유
`org.jsoup:jsoup:1.17.2`는 [CVE-2024-32104](https://nvd.nist.gov/vuln/detail/CVE-2024-32104)의 영향 라인으로, 특정 속성명이 포함된 HTML에 대해 `SafeList` 기반 sanitizer 우회가 가능했습니다. 1.18.x 라인에서 sanitizer 회귀를 수정하고 파서 강화가 적용되었습니다.

본 리포에서 jsoup을 직접 pin 하는 모듈은 `EgovBoard` 뿐입니다.

## 변경 내용
- `EgovBoard/pom.xml` 단일 줄 수정: `<version>1.17.2</version>` → `<version>1.18.3</version>`

## 영향 범위
- jsoup public API 1.17 ↔ 1.18 호환 유지 (`Document`, `Element`, `Jsoup.clean()` 등)
- 호출부 코드 변경 없음

## 체크리스트
- [x] 단일 주제(jsoup 패치)
- [x] 5.0.x 브랜치 대상
- [x] 호출부 코드 변경 없음