### PR TITLE
[chore] Add Dependabot configuration for Maven modules, Actions, and Docker

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,58 @@
+version: 2
+updates:
+  # Maven modules (multi-module Spring Boot project)
+  - package-ecosystem: "maven"
+    directories:
+      - "/ConfigServer"
+      - "/EgovAuthor"
+      - "/EgovBoard"
+      - "/EgovCmmnCode"
+      - "/EgovLogin"
+      - "/EgovLoginPolicy"
+      - "/EgovMain"
+      - "/EgovMobileId"
+      - "/EgovQuestionnaire"
+      - "/EgovSearch"
+      - "/EgovSearch-Config"
+      - "/EurekaServer"
+      - "/GatewayServer"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "ci"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+
+  - package-ecosystem: "docker"
+    directories:
+      - "/docker-compose"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Seoul"
+    open-pull-requests-limit: 3
+    labels:
+      - "docker"
+    commit-message:
+      prefix: "docker"
+      include: "scope"


### PR DESCRIPTION
## 변경 사유
멀티 모듈(13개 Spring Boot 모듈)과 `docker-compose` 인프라가 있는 본 리포에 `.github/dependabot.yml`이 없어 의존성 패치가 수동입니다. 모듈 단위로 자동 의존성 업데이트 PR을 받도록 설정합니다.

## 변경 내용
- `.github/dependabot.yml` 신규 추가
  - maven (per-module): 13개 모듈 디렉토리 등록, 주간 스캔, 동시 PR 10개
  - github-actions: 주간 스캔, 동시 PR 3개
  - docker (docker-compose 디렉토리): 주간 스캔, 동시 PR 3개
  - 스케줄: 매주 월요일 09:00 KST

## 영향 범위
- 기존 코드/빌드 영향 없음
- 머지 후 첫 월요일에 Dependabot 시작

## 체크리스트
- [x] 단일 주제(자동 의존성 관리 설정)
- [x] 5.0.x 브랜치 대상
- [x] 기존 동작 미변경