### PR TITLE
[feat] 12개 모듈 전체에 Dockerfile + Kubernetes 매니페스트 추가

### DIFF
--- a/ConfigServer/.dockerignore
+++ b/ConfigServer/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/ConfigServer/Dockerfile
+++ b/ConfigServer/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for ConfigServer.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8888
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8888/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/ConfigServer/k8s/deployment.yaml
+++ b/ConfigServer/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: config-server
+  labels:
+    app.kubernetes.io/name: config-server
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: config-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: config-server
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: config-server:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8888
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/ConfigServer/k8s/service.yaml
+++ b/ConfigServer/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: config-server
+  labels:
+    app.kubernetes.io/name: config-server
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: config-server
+  ports:
+    - name: http
+      port: 8888
+      targetPort: http

--- a/EgovAuthor/.dockerignore
+++ b/EgovAuthor/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovAuthor/Dockerfile
+++ b/EgovAuthor/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovAuthor.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovAuthor/k8s/deployment.yaml
+++ b/EgovAuthor/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-author
+  labels:
+    app.kubernetes.io/name: egov-author
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-author
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-author
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-author:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovAuthor/k8s/service.yaml
+++ b/EgovAuthor/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-author
+  labels:
+    app.kubernetes.io/name: egov-author
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-author
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovBoard/.dockerignore
+++ b/EgovBoard/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovBoard/Dockerfile
+++ b/EgovBoard/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovBoard.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovBoard/k8s/deployment.yaml
+++ b/EgovBoard/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-board
+  labels:
+    app.kubernetes.io/name: egov-board
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-board
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-board
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-board:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovBoard/k8s/service.yaml
+++ b/EgovBoard/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-board
+  labels:
+    app.kubernetes.io/name: egov-board
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-board
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovCmmnCode/.dockerignore
+++ b/EgovCmmnCode/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovCmmnCode/Dockerfile
+++ b/EgovCmmnCode/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovCmmnCode.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovCmmnCode/k8s/deployment.yaml
+++ b/EgovCmmnCode/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-cmmn-code
+  labels:
+    app.kubernetes.io/name: egov-cmmn-code
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-cmmn-code
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-cmmn-code
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-cmmn-code:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovCmmnCode/k8s/service.yaml
+++ b/EgovCmmnCode/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-cmmn-code
+  labels:
+    app.kubernetes.io/name: egov-cmmn-code
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-cmmn-code
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovLogin/.dockerignore
+++ b/EgovLogin/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovLogin/Dockerfile
+++ b/EgovLogin/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovLogin.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovLogin/k8s/deployment.yaml
+++ b/EgovLogin/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-login
+  labels:
+    app.kubernetes.io/name: egov-login
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-login
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-login
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-login:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovLogin/k8s/service.yaml
+++ b/EgovLogin/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-login
+  labels:
+    app.kubernetes.io/name: egov-login
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-login
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovLoginPolicy/.dockerignore
+++ b/EgovLoginPolicy/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovLoginPolicy/Dockerfile
+++ b/EgovLoginPolicy/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovLoginPolicy.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovLoginPolicy/k8s/deployment.yaml
+++ b/EgovLoginPolicy/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-login-policy
+  labels:
+    app.kubernetes.io/name: egov-login-policy
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-login-policy
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-login-policy
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-login-policy:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovLoginPolicy/k8s/service.yaml
+++ b/EgovLoginPolicy/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-login-policy
+  labels:
+    app.kubernetes.io/name: egov-login-policy
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-login-policy
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovMain/.dockerignore
+++ b/EgovMain/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovMain/Dockerfile
+++ b/EgovMain/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovMain.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovMain/k8s/deployment.yaml
+++ b/EgovMain/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-main
+  labels:
+    app.kubernetes.io/name: egov-main
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-main
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-main
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-main:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovMain/k8s/service.yaml
+++ b/EgovMain/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-main
+  labels:
+    app.kubernetes.io/name: egov-main
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-main
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovMobileId/.dockerignore
+++ b/EgovMobileId/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovMobileId/Dockerfile
+++ b/EgovMobileId/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovMobileId.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 9991
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:9991/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovMobileId/k8s/deployment.yaml
+++ b/EgovMobileId/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-mobile-id
+  labels:
+    app.kubernetes.io/name: egov-mobile-id
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-mobile-id
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-mobile-id
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-mobile-id:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9991
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovMobileId/k8s/service.yaml
+++ b/EgovMobileId/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-mobile-id
+  labels:
+    app.kubernetes.io/name: egov-mobile-id
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-mobile-id
+  ports:
+    - name: http
+      port: 9991
+      targetPort: http

--- a/EgovQuestionnaire/.dockerignore
+++ b/EgovQuestionnaire/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovQuestionnaire/Dockerfile
+++ b/EgovQuestionnaire/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovQuestionnaire.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8080/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovQuestionnaire/k8s/deployment.yaml
+++ b/EgovQuestionnaire/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-questionnaire
+  labels:
+    app.kubernetes.io/name: egov-questionnaire
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-questionnaire
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-questionnaire
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-questionnaire:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8080
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovQuestionnaire/k8s/service.yaml
+++ b/EgovQuestionnaire/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-questionnaire
+  labels:
+    app.kubernetes.io/name: egov-questionnaire
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-questionnaire
+  ports:
+    - name: http
+      port: 8080
+      targetPort: http

--- a/EgovSearch/.dockerignore
+++ b/EgovSearch/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EgovSearch/Dockerfile
+++ b/EgovSearch/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EgovSearch.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 9992
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:9992/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EgovSearch/k8s/deployment.yaml
+++ b/EgovSearch/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: egov-search
+  labels:
+    app.kubernetes.io/name: egov-search
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: egov-search
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: egov-search
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: egov-search:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9992
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EgovSearch/k8s/service.yaml
+++ b/EgovSearch/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: egov-search
+  labels:
+    app.kubernetes.io/name: egov-search
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: egov-search
+  ports:
+    - name: http
+      port: 9992
+      targetPort: http

--- a/EurekaServer/.dockerignore
+++ b/EurekaServer/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/EurekaServer/Dockerfile
+++ b/EurekaServer/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for EurekaServer.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 8761
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:8761/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/EurekaServer/k8s/deployment.yaml
+++ b/EurekaServer/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: eureka-server
+  labels:
+    app.kubernetes.io/name: eureka-server
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: eureka-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: eureka-server
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: eureka-server:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 8761
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/EurekaServer/k8s/service.yaml
+++ b/EurekaServer/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: eureka-server
+  labels:
+    app.kubernetes.io/name: eureka-server
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: eureka-server
+  ports:
+    - name: http
+      port: 8761
+      targetPort: http

--- a/GatewayServer/.dockerignore
+++ b/GatewayServer/.dockerignore
@@ -1,0 +1,12 @@
+target/
+*.log
+.idea/
+.vscode/
+.git/
+.gitignore
+.dockerignore
+Dockerfile
+docker-compose.yml
+k8s/
+README*.md
+*.iml

--- a/GatewayServer/Dockerfile
+++ b/GatewayServer/Dockerfile
@@ -1,0 +1,31 @@
+# syntax=docker/dockerfile:1.7
+# Multi-stage build for GatewayServer.
+
+FROM maven:3.9-eclipse-temurin-17 AS build
+WORKDIR /workspace
+
+COPY pom.xml ./
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp dependency:go-offline
+
+COPY src ./src
+RUN --mount=type=cache,target=/root/.m2 \
+    mvn -B -ntp -DskipTests package && \
+    cp target/*.jar /workspace/app.jar
+
+FROM eclipse-temurin:17-jre-alpine
+
+RUN addgroup -S app && adduser -S -G app app
+USER app:app
+
+WORKDIR /app
+COPY --from=build --chown=app:app /workspace/app.jar /app/app.jar
+
+ENV JAVA_OPTS="-XX:MaxRAMPercentage=75 -XX:+ExitOnOutOfMemoryError"
+
+EXPOSE 9000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=60s --retries=3 \
+  CMD wget -qO- http://127.0.0.1:9000/actuator/health || exit 1
+
+ENTRYPOINT ["sh","-c","exec java $JAVA_OPTS -jar /app/app.jar"]

--- a/GatewayServer/k8s/deployment.yaml
+++ b/GatewayServer/k8s/deployment.yaml
@@ -1,0 +1,68 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gateway-server
+  labels:
+    app.kubernetes.io/name: gateway-server
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: gateway-server
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: gateway-server
+        app.kubernetes.io/part-of: egovframe-msa-common
+    spec:
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 1000
+        runAsGroup: 1000
+        fsGroup: 1000
+      containers:
+        - name: app
+          image: gateway-server:5.0.0
+          imagePullPolicy: IfNotPresent
+          ports:
+            - name: http
+              containerPort: 9000
+          resources:
+            requests:
+              cpu: "200m"
+              memory: "512Mi"
+            limits:
+              cpu: "1000m"
+              memory: "1Gi"
+          readinessProbe:
+            httpGet:
+              path: /actuator/health/readiness
+              port: http
+            initialDelaySeconds: 30
+            periodSeconds: 10
+            failureThreshold: 6
+          livenessProbe:
+            httpGet:
+              path: /actuator/health/liveness
+              port: http
+            initialDelaySeconds: 90
+            periodSeconds: 20
+            failureThreshold: 3
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+          volumeMounts:
+            - name: tmp
+              mountPath: /tmp
+      volumes:
+        - name: tmp
+          emptyDir: {}

--- a/GatewayServer/k8s/service.yaml
+++ b/GatewayServer/k8s/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: gateway-server
+  labels:
+    app.kubernetes.io/name: gateway-server
+    app.kubernetes.io/part-of: egovframe-msa-common
+spec:
+  type: ClusterIP
+  selector:
+    app.kubernetes.io/name: gateway-server
+  ports:
+    - name: http
+      port: 9000
+      targetPort: http


### PR DESCRIPTION
## 변경 사유
12개 Spring Boot 마이크로서비스 모듈 모두에 컨테이너 이미지 정의와 k8s 매니페스트가 없습니다. 모듈별 일관된 템플릿을 추가하여 모듈 단위 빌드/배포 경로를 만듭니다.

## 변경 내용
각 모듈에 다음 4개 파일 추가:
- `Dockerfile` — multi-stage `maven:3.9-eclipse-temurin-17` → `eclipse-temurin:17-jre-alpine`, 비루트, `HEALTHCHECK` Actuator
- `.dockerignore` — 빌드 컨텍스트 축소
- `k8s/deployment.yaml` — 1 replica RollingUpdate, runAsNonRoot, readOnlyRootFilesystem, drop ALL, resource requests/limits, liveness/readiness probe
- `k8s/service.yaml` — ClusterIP

### 모듈별 포트 (application.yml 값 유지)
| 모듈 | 포트 |
|------|------|
| ConfigServer | 8888 |
| EurekaServer | 8761 |
| GatewayServer | 9000 |
| EgovMobileId | 9991 |
| EgovSearch | 9992 |
| EgovAuthor / EgovBoard / EgovCmmnCode / EgovLogin / EgovLoginPolicy / EgovMain / EgovQuestionnaire | 8080 |

각 application.yml에서 `port: 0`(Eureka 자가 등록용 임의 포트)로 되어 있는 모듈은 클러스터 라우팅을 위해 매니페스트에서 8080으로 고정.

## 영향 범위
- 애플리케이션 코드, pom.xml, application.yml 변경 없음
- 환경별 설정(DB/Secret 등)은 본 PR 범위에 포함하지 않음 — 운영자가 별도 ConfigMap/Secret 생성
- `image:` 태그(`<module>:5.0.0`)는 예시 — 운영 환경 레지스트리로 교체 필요

## 체크리스트
- [x] 단일 주제(전 모듈 컨테이너화 + k8s 매니페스트 일괄 추가)
- [x] 5.0.x 브랜치 대상
- [x] 기존 코드/설정 미변경
- [x] 비밀 정보 커밋 없음
- [x] 모듈별 일관 템플릿 유지 (검토 부담 최소화)