### PR TITLE
[test][EgovBoard] 단위 테스트 신설 (모듈 최초 테스트)

### DIFF
--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/service/EgovBbsMasterServiceImplTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/service/EgovBbsMasterServiceImplTest.java
@@ -1,0 +1,91 @@
+package egovframework.com.cop.brd.service;
+
+import egovframework.com.cop.brd.entity.BbsMaster;
+import egovframework.com.cop.brd.repository.EgovBbsMasterOptnRepository;
+import egovframework.com.cop.brd.repository.EgovBbsMasterRepository;
+import egovframework.com.cop.brd.service.impl.EgovBbsMasterServiceImpl;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * EgovBbsMasterServiceImpl 단위 테스트.
+ * Mockito만 사용하므로 DB·Eureka·RabbitMQ 연결이 불필요하다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovBbsMasterServiceImplTest {
+
+    @Mock
+    private EgovBbsMasterOptnRepository optnRepository;
+
+    @Mock
+    private EgovBbsMasterRepository masterRepository;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    private EgovBbsMasterServiceImpl service;
+
+    @Test
+    @DisplayName("isBbsMasterOptnAccessible: bbsId 또는 uniqId가 null/공백이면 false를 반환한다")
+    void isBbsMasterOptnAccessible_nullOrBlankArgs_returnsFalse() {
+        assertThat(service.isBbsMasterOptnAccessible(null, "USER01")).isFalse();
+        assertThat(service.isBbsMasterOptnAccessible("", "USER01")).isFalse();
+        assertThat(service.isBbsMasterOptnAccessible("   ", "USER01")).isFalse();
+        assertThat(service.isBbsMasterOptnAccessible("BBSMSTR_0001", null)).isFalse();
+        assertThat(service.isBbsMasterOptnAccessible("BBSMSTR_0001", "")).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBbsMasterOptnAccessible: useAt=Y인 게시판이면 true를 반환한다")
+    void isBbsMasterOptnAccessible_activeBoard_returnsTrue() {
+        // given
+        BbsMaster master = new BbsMaster();
+        master.setUseAt("Y");
+        given(masterRepository.findById("BBSMSTR_0001")).willReturn(Optional.of(master));
+
+        // when
+        boolean result = service.isBbsMasterOptnAccessible("BBSMSTR_0001", "USER01");
+
+        // then
+        assertThat(result).isTrue();
+    }
+
+    @Test
+    @DisplayName("isBbsMasterOptnAccessible: useAt=N인 게시판이면 false를 반환한다")
+    void isBbsMasterOptnAccessible_inactiveBoard_returnsFalse() {
+        // given
+        BbsMaster master = new BbsMaster();
+        master.setUseAt("N");
+        given(masterRepository.findById("BBSMSTR_0002")).willReturn(Optional.of(master));
+
+        // when
+        boolean result = service.isBbsMasterOptnAccessible("BBSMSTR_0002", "USER01");
+
+        // then
+        assertThat(result).isFalse();
+    }
+
+    @Test
+    @DisplayName("isBbsMasterOptnAccessible: 존재하지 않는 게시판 ID이면 false를 반환한다")
+    void isBbsMasterOptnAccessible_notFoundBoard_returnsFalse() {
+        // given
+        given(masterRepository.findById("BBSMSTR_NONE")).willReturn(Optional.empty());
+
+        // when
+        boolean result = service.isBbsMasterOptnAccessible("BBSMSTR_NONE", "USER01");
+
+        // then
+        assertThat(result).isFalse();
+    }
+}

--- a/EgovBoard/src/test/java/egovframework/com/cop/brd/util/EgovBoardUtilityTest.java
+++ b/EgovBoard/src/test/java/egovframework/com/cop/brd/util/EgovBoardUtilityTest.java
@@ -1,0 +1,97 @@
+package egovframework.com.cop.brd.util;
+
+import egovframework.com.cop.brd.entity.Bbs;
+import egovframework.com.cop.brd.entity.BbsId;
+import egovframework.com.cop.brd.entity.Comment;
+import egovframework.com.cop.brd.entity.CommentId;
+import egovframework.com.cop.brd.service.BbsVO;
+import egovframework.com.cop.brd.service.CommentVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovBoardUtility 단위 테스트.
+ * 외부 의존성(DB, Eureka, RabbitMQ) 없이 순수 변환 로직만 검증한다.
+ */
+class EgovBoardUtilityTest {
+
+    @Test
+    @DisplayName("bbsEntityToVO: Bbs 엔티티의 복합 키가 VO 필드로 올바르게 매핑된다")
+    void bbsEntityToVO_shouldMapEmbeddedIdToVO() {
+        // given
+        BbsId bbsId = new BbsId();
+        bbsId.setBbsId("BBSMSTR_000000000001");
+        bbsId.setNttId(10L);
+
+        Bbs bbs = new Bbs();
+        bbs.setBbsId(bbsId);
+        bbs.setNttNo(1);
+        bbs.setParntscttNo(0);
+        bbs.setAnswerLc(0);
+        bbs.setSortOrdr(1);
+        bbs.setRdcnt(0);
+        bbs.setNttSj("테스트 게시글 제목");
+        bbs.setUseAt("Y");
+        bbs.setNtcrNm("홍길동");
+
+        // when
+        BbsVO vo = EgovBoardUtility.bbsEntityToVO(bbs);
+
+        // then
+        assertThat(vo.getBbsId()).isEqualTo("BBSMSTR_000000000001");
+        assertThat(vo.getNttId()).isEqualTo(10L);
+        assertThat(vo.getNttSj()).isEqualTo("테스트 게시글 제목");
+        assertThat(vo.getUseAt()).isEqualTo("Y");
+        assertThat(vo.getNtcrNm()).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("bbsVOToEntity: BbsVO에서 Bbs 엔티티로 변환 시 복합 키가 올바르게 설정된다")
+    void bbsVOToEntity_shouldSetEmbeddedIdFromVO() {
+        // given
+        BbsVO vo = new BbsVO();
+        vo.setBbsId("BBSMSTR_000000000002");
+        vo.setNttId(20L);
+        vo.setNttSj("변환 테스트");
+        vo.setNttCn("본문 내용");
+        vo.setFrstRegisterId("USER001");
+
+        // when
+        Bbs entity = EgovBoardUtility.bbsVOToEntity(vo);
+
+        // then
+        assertThat(entity.getBbsId().getBbsId()).isEqualTo("BBSMSTR_000000000002");
+        assertThat(entity.getBbsId().getNttId()).isEqualTo(20L);
+        assertThat(entity.getNttSj()).isEqualTo("변환 테스트");
+        assertThat(entity.getNtcrId()).isEqualTo("USER001");
+        assertThat(entity.getFrstRegistPnttm()).isNotNull();
+        assertThat(entity.getLastUpdtPnttm()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("commentEntityToVO: Comment 복합 키가 CommentVO 필드로 올바르게 매핑된다")
+    void commentEntityToVO_shouldMapCompositeKeyToVO() {
+        // given
+        CommentId commentId = new CommentId();
+        commentId.setBbsId("BBSMSTR_000000000003");
+        commentId.setNttId(30L);
+        commentId.setAnswerNo(1L);
+
+        Comment comment = new Comment();
+        comment.setCommentId(commentId);
+        comment.setAnswer("댓글 내용");
+        comment.setUseAt("Y");
+
+        // when
+        CommentVO vo = EgovBoardUtility.commentEntityToVO(comment);
+
+        // then
+        assertThat(vo.getBbsId()).isEqualTo("BBSMSTR_000000000003");
+        assertThat(vo.getNttId()).isEqualTo(30L);
+        assertThat(vo.getAnswerNo()).isEqualTo(1L);
+        assertThat(vo.getAnswer()).isEqualTo("댓글 내용");
+        assertThat(vo.getUseAt()).isEqualTo("Y");
+    }
+}


### PR DESCRIPTION
## 변경 사유

13개 모듈 모두 `src/test/java`가 없어 자동화된 회귀 방어 수단이 전혀 없는 상태입니다.
EgovBoard 모듈부터 외부 의존성 없이 즉시 실행 가능한 단위 테스트를 추가해 최소한의 방어선을 마련합니다.

## 변경 내용

추가한 테스트 클래스 2개 (production 코드 변경 없음):

**1. `EgovBoardUtilityTest`** — `egovframework.com.cop.brd.util` 패키지
- `bbsEntityToVO`: `Bbs` 엔티티의 복합 키(`BbsId`)가 `BbsVO` 필드로 정확히 매핑되는지 검증
- `bbsVOToEntity`: `BbsVO` → `Bbs` 엔티티 변환 시 복합 키 설정 및 등록 일시 자동 세팅 검증
- `commentEntityToVO`: `Comment` 복합 키(`CommentId`)가 `CommentVO` 필드로 정확히 매핑되는지 검증

**2. `EgovBbsMasterServiceImplTest`** — `egovframework.com.cop.brd.service` 패키지
- `isBbsMasterOptnAccessible` 메서드의 경계 조건 4케이스 검증:
  - `bbsId` 또는 `uniqId`가 null·공백이면 `false` 반환
  - `useAt = "Y"` 인 게시판이면 `true` 반환
  - `useAt = "N"` 인 게시판이면 `false` 반환
  - 존재하지 않는 게시판 ID면 `false` 반환

## 외부 의존성 우회 방식

- `EgovBoardUtilityTest`: `@ExtendWith` 없이 순수 Java — 스프링 컨텍스트 불필요
- `EgovBbsMasterServiceImplTest`: `@ExtendWith(MockitoExtension.class)` 사용, `EgovBbsMasterRepository` · `EgovBbsMasterOptnRepository` · `JPAQueryFactory` 전부 `@Mock` 처리
- DB·Eureka·RabbitMQ 연결 없이 `mvn test -Dtest="EgovBoardUtilityTest,EgovBbsMasterServiceImplTest"` 으로 즉시 실행 가능 (로컬 실행 결과: Tests run: 7, Failures: 0, Errors: 0)

## 향후 확장

동일 패턴(`@ExtendWith(MockitoExtension.class)` + Repository Mock)을 나머지 12개 모듈(`EgovLogin`, `EgovCmmnCode`, `EgovSearch` 등)에 순차 적용할 수 있습니다.

## 영향 범위

production 코드 변경 없음. 테스트 클래스 2개 추가만.

---

- [x] 단일 주제만 다룸 (테스트 추가 외 변경 없음)
- [x] 5.x 다른 브랜치용 PR이 필요한 경우 후속 PR 링크 명시 — 현재 5.0.x 단일, 필요 시 추가 예정
- [x] 기존 동작에 영향 없음 (production 코드 무변경)
- [x] 테스트 통과 확인 (로컬 7/7 pass)