### PR TITLE
[test][EgovLogin] 단위 테스트 신설

### DIFF
--- a/EgovLogin/src/test/java/egovframework/com/uat/uia/service/EgovLoginManageServiceImplTest.java
+++ b/EgovLogin/src/test/java/egovframework/com/uat/uia/service/EgovLoginManageServiceImplTest.java
@@ -1,0 +1,163 @@
+package egovframework.com.uat.uia.service;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import egovframework.com.uat.uia.entity.LoginPolicy;
+import egovframework.com.uat.uia.repository.EgovEmployMemberRepository;
+import egovframework.com.uat.uia.repository.EgovEnterpriseMemberRepository;
+import egovframework.com.uat.uia.repository.EgovGeneralMemberRepository;
+import egovframework.com.uat.uia.repository.EgovLoginPolicyRepository;
+import egovframework.com.uat.uia.service.impl.EgovLoginManageServiceImpl;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * EgovLoginManageServiceImpl 단위 테스트.
+ * Mockito만 사용하므로 DB·Eureka·Redis 연결 없이 실행된다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovLoginManageServiceImplTest {
+
+    @Mock
+    private EgovGeneralMemberRepository genRepository;
+
+    @Mock
+    private EgovEnterpriseMemberRepository entRepository;
+
+    @Mock
+    private EgovEmployMemberRepository empRepository;
+
+    @Mock
+    private EgovLoginPolicyRepository loginPolicyRepository;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    private EgovLoginManageServiceImpl service;
+
+    // ---------------------------------------------------------------
+    // loginPolicy
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("loginPolicy: 해당 employer ID가 DB에 존재하면 정책 정보를 채워 반환한다")
+    void loginPolicy_existingEmployer_returnsPolicyData() {
+        // given
+        LoginPolicy policy = new LoginPolicy();
+        policy.setEmployerId("USER001");
+        policy.setLmttAt("Y");
+        policy.setIpInfo("192.168.0.1");
+        given(loginPolicyRepository.findById("USER001")).willReturn(Optional.of(policy));
+
+        LoginPolicyVO vo = new LoginPolicyVO();
+        vo.setEmployerId("USER001");
+
+        // when
+        LoginPolicyVO result = service.loginPolicy(vo);
+
+        // then
+        assertThat(result.getEmployerId()).isEqualTo("USER001");
+        assertThat(result.getLmttAt()).isEqualTo("Y");
+        assertThat(result.getIpInfo()).isEqualTo("192.168.0.1");
+    }
+
+    @Test
+    @DisplayName("loginPolicy: 해당 employer ID가 DB에 없으면 VO를 그대로 반환한다")
+    void loginPolicy_notFoundEmployer_returnsUnchangedVO() {
+        // given
+        given(loginPolicyRepository.findById("UNKNOWN")).willReturn(Optional.empty());
+
+        LoginPolicyVO vo = new LoginPolicyVO();
+        vo.setEmployerId("UNKNOWN");
+
+        // when
+        LoginPolicyVO result = service.loginPolicy(vo);
+
+        // then
+        assertThat(result.getEmployerId()).isEqualTo("UNKNOWN");
+        assertThat(result.getLmttAt()).isNull();
+        assertThat(result.getIpInfo()).isNull();
+    }
+
+    // ---------------------------------------------------------------
+    // loginIncorrectList
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("loginIncorrectList: userId 또는 userSe가 비어 있으면 null을 반환한다")
+    void loginIncorrectList_emptyUserIdOrSe_returnsNull() {
+        LoginVO loginVO1 = new LoginVO();
+        loginVO1.setUserId("");
+        loginVO1.setUserSe("GNR");
+        assertThat(service.loginIncorrectList(loginVO1)).isNull();
+
+        LoginVO loginVO2 = new LoginVO();
+        loginVO2.setUserId("USER001");
+        loginVO2.setUserSe("");
+        assertThat(service.loginIncorrectList(loginVO2)).isNull();
+    }
+
+    @Test
+    @DisplayName("loginIncorrectList: 알 수 없는 userSe이면 null을 반환한다")
+    void loginIncorrectList_unknownUserSe_returnsNull() {
+        LoginVO loginVO = new LoginVO();
+        loginVO.setUserId("USER001");
+        loginVO.setUserSe("UNKNOWN");
+
+        assertThat(service.loginIncorrectList(loginVO)).isNull();
+    }
+
+    @Test
+    @DisplayName("loginIncorrectList: GNR 사용자가 존재하지 않으면 null을 반환한다")
+    void loginIncorrectList_gnrUserNotFound_returnsNull() {
+        given(genRepository.findById("MISSING")).willReturn(Optional.empty());
+
+        LoginVO loginVO = new LoginVO();
+        loginVO.setUserId("MISSING");
+        loginVO.setUserSe("GNR");
+
+        assertThat(service.loginIncorrectList(loginVO)).isNull();
+    }
+
+    // ---------------------------------------------------------------
+    // loginIncorrectProcess
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("loginIncorrectProcess: userId 또는 userSe가 비어 있으면 'C'를 반환한다")
+    void loginIncorrectProcess_emptyInput_returnsC() {
+        LoginVO loginVO = new LoginVO();
+        loginVO.setUserId("");
+        loginVO.setUserSe("GNR");
+        loginVO.setUserPw("pw");
+
+        LoginIncorrectVO incorrectVO = new LoginIncorrectVO("", "encoded", "홍길동", "GNR", "ESNTL001", "N", 0);
+
+        String result = service.loginIncorrectProcess(loginVO, incorrectVO, "5");
+        assertThat(result).isEqualTo("C");
+    }
+
+    @Test
+    @DisplayName("loginIncorrectProcess: 계정이 이미 잠겨 있으면 'L'을 반환한다")
+    void loginIncorrectProcess_lockedAccount_returnsL() {
+        LoginVO loginVO = new LoginVO();
+        loginVO.setUserId("USER001");
+        loginVO.setUserSe("GNR");
+        loginVO.setUserPw("wrongPw");
+
+        // lockAt=Y이면 비밀번호 불일치와 관계없이 'L' 반환
+        LoginIncorrectVO incorrectVO = new LoginIncorrectVO("USER001", "somethingElse", "홍길동", "GNR", "ESNTL001", "Y", 3);
+
+        String result = service.loginIncorrectProcess(loginVO, incorrectVO, "5");
+        assertThat(result).isEqualTo("L");
+    }
+}

--- a/EgovLogin/src/test/java/egovframework/com/uat/uia/util/EgovClientIPTest.java
+++ b/EgovLogin/src/test/java/egovframework/com/uat/uia/util/EgovClientIPTest.java
@@ -1,0 +1,33 @@
+package egovframework.com.uat.uia.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovClientIP 단위 테스트.
+ * 외부 의존성 없이 순수 로직만 검증한다.
+ */
+class EgovClientIPTest {
+
+    @Test
+    @DisplayName("getClientIp: 반환값이 null이 아니고 빈 문자열이 아니다")
+    void getClientIp_returnsNonBlankString() {
+        String ip = EgovClientIP.getClientIp();
+        assertThat(ip).isNotNull().isNotBlank();
+    }
+
+    @Test
+    @DisplayName("getClientIp: 반환값이 IP 형식이거나 네트워크 접근 불가 시 '0.0.0.0'이다")
+    void getClientIp_returnsValidIpOrFallback() {
+        String ip = EgovClientIP.getClientIp();
+        // IPv4, IPv6, 또는 fallback '0.0.0.0' 중 하나여야 한다
+        boolean isIpv4 = ip.matches("\\d{1,3}(\\.\\d{1,3}){3}");
+        boolean isIpv6 = ip.contains(":");
+        boolean isFallback = "0.0.0.0".equals(ip);
+        assertThat(isIpv4 || isIpv6 || isFallback)
+                .as("IP 형식이거나 fallback '0.0.0.0'이어야 한다: %s", ip)
+                .isTrue();
+    }
+}


### PR DESCRIPTION
## 변경 사유

EgovLogin 모듈에 테스트 코드가 전혀 없어 핵심 비즈니스 로직의 동작 검증이 불가능한 상태였다.
로그인 정책 조회, 로그인 실패 처리, 클라이언트 IP 조회 등 주요 경로를 단위 테스트로 보강한다.

## 변경 내용

추가 파일 2개 (production 코드 변경 없음):

- `EgovLogin/src/test/java/egovframework/com/uat/uia/service/EgovLoginManageServiceImplTest.java`
  - `loginPolicy`: 정책 존재 시 필드 반환, 미존재 시 VO 원본 반환
  - `loginIncorrectList`: 빈 입력·알 수 없는 userSe·미존재 GNR 회원 → null 반환
  - `loginIncorrectProcess`: 빈 입력 → "C", 계정 잠금 → "L"
- `EgovLogin/src/test/java/egovframework/com/uat/uia/util/EgovClientIPTest.java`
  - `getClientIp()` 반환값 비공백·IP 형식(IPv4/IPv6/fallback) 검증

## 테스트 방법

```
mvn -B -ntp -pl EgovLogin test
```

로컬 실행 결과: `Tests run: 9, Failures: 0, Errors: 0, Skipped: 0`

Mockito `@ExtendWith(MockitoExtension.class)` 기반 순수 단위 테스트로 작성하여
DB·Eureka·Redis 등 외부 인프라 없이 실행된다.

## 체크리스트

- [x] 단일 주제만 다룸 (테스트 추가, 다른 변경 없음)
- [x] production 코드 변경 없음
- [x] 외부 서비스(DB/Eureka/Redis) 실제 접근 없음
- [x] 기존 동작에 영향 없음
- [x] 로컬 테스트 통과 확인