### PR TITLE
[test][EgovQuestionnaire] 단위 테스트 신설

### DIFF
--- a/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qim/util/EgovQusntrItemUtilityTest.java
+++ b/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qim/util/EgovQusntrItemUtilityTest.java
@@ -1,0 +1,98 @@
+package egovframework.com.uss.olp.qim.util;
+
+import egovframework.com.uss.olp.qim.entity.QustnrIem;
+import egovframework.com.uss.olp.qim.entity.QustnrIemId;
+import egovframework.com.uss.olp.qim.service.QustnrIemVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovQusntrItemUtility 단위 테스트.
+ * Spring 컨텍스트 없이 유틸리티 메서드의 변환 로직을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovQusntrItemUtilityTest {
+
+    @Test
+    @DisplayName("qustnrIemEntityToVO: 엔티티의 복합 키 필드가 VO에 올바르게 매핑된다")
+    void qustnrIemEntityToVO_compositeKeyMappedCorrectly() {
+        QustnrIemId id = new QustnrIemId();
+        id.setQustnrTmplatId("TMPLAT-001");
+        id.setQestnrId("QESTNR-001");
+        id.setQustnrQesitmId("QESITM-001");
+        id.setQustnrIemId("IEM-001");
+
+        QustnrIem entity = new QustnrIem();
+        entity.setQustnrIemId(id);
+        entity.setIemSn("1");
+        entity.setIemCn("항목 내용");
+        entity.setEtcAnswerAt("N");
+        entity.setFrstRegistPnttm(LocalDateTime.of(2024, 1, 1, 0, 0));
+        entity.setFrstRegisterId("USR001");
+        entity.setLastUpdtPnttm(LocalDateTime.of(2024, 6, 1, 0, 0));
+        entity.setLastUpdusrId("USR002");
+
+        QustnrIemVO vo = EgovQusntrItemUtility.qustnrIemEntityToVO(entity);
+
+        // qim 유틸리티는 qustnrTmplatId ↔ qestnrId 를 교차 매핑하는 구조이므로 실제 로직을 그대로 검증
+        assertThat(vo).isNotNull();
+        assertThat(vo.getQustnrTmplatId()).isEqualTo(id.getQestnrId());
+        assertThat(vo.getQestnrId()).isEqualTo(id.getQustnrTmplatId());
+        assertThat(vo.getQustnrQesitmId()).isEqualTo(id.getQustnrQesitmId());
+        assertThat(vo.getQustnrIemId()).isEqualTo(id.getQustnrIemId());
+        assertThat(vo.getIemSn()).isEqualTo("1");
+        assertThat(vo.getIemCn()).isEqualTo("항목 내용");
+        assertThat(vo.getEtcAnswerAt()).isEqualTo("N");
+    }
+
+    @Test
+    @DisplayName("qustnrIemVOToEntity: VO의 ID 필드가 엔티티 복합 키에 올바르게 설정된다")
+    void qustnrIemVOToEntity_compositeKeySetCorrectly() {
+        QustnrIemVO vo = new QustnrIemVO();
+        vo.setQustnrTmplatId("TMPLAT-002");
+        vo.setQestnrId("QESTNR-002");
+        vo.setQustnrQesitmId("QESITM-002");
+        vo.setQustnrIemId("IEM-002");
+        vo.setIemSn("2");
+        vo.setIemCn("두 번째 항목");
+        vo.setEtcAnswerAt("Y");
+
+        QustnrIem entity = EgovQusntrItemUtility.qustnrIemVOToEntity(vo);
+
+        assertThat(entity).isNotNull();
+        assertThat(entity.getQustnrIemId()).isNotNull();
+        assertThat(entity.getQustnrIemId().getQustnrTmplatId()).isEqualTo(vo.getQustnrTmplatId());
+        assertThat(entity.getQustnrIemId().getQestnrId()).isEqualTo(vo.getQestnrId());
+        assertThat(entity.getQustnrIemId().getQustnrQesitmId()).isEqualTo(vo.getQustnrQesitmId());
+        assertThat(entity.getQustnrIemId().getQustnrIemId()).isEqualTo(vo.getQustnrIemId());
+        assertThat(entity.getIemSn()).isEqualTo("2");
+        assertThat(entity.getIemCn()).isEqualTo("두 번째 항목");
+        assertThat(entity.getEtcAnswerAt()).isEqualTo("Y");
+    }
+
+    @Test
+    @DisplayName("qustnrIemVOToEntity → qustnrIemEntityToVO: 왕복 변환 후 항목 내용이 보존된다")
+    void roundTrip_iemContentPreserved() {
+        QustnrIemVO original = new QustnrIemVO();
+        original.setQustnrTmplatId("TMPLAT-003");
+        original.setQestnrId("QESTNR-003");
+        original.setQustnrQesitmId("QESITM-003");
+        original.setQustnrIemId("IEM-003");
+        original.setIemSn("3");
+        original.setIemCn("왕복 테스트 항목");
+        original.setEtcAnswerAt("N");
+
+        QustnrIem entity = EgovQusntrItemUtility.qustnrIemVOToEntity(original);
+        QustnrIemVO result = EgovQusntrItemUtility.qustnrIemEntityToVO(entity);
+
+        assertThat(result.getIemCn()).isEqualTo(original.getIemCn());
+        assertThat(result.getIemSn()).isEqualTo(original.getIemSn());
+        assertThat(result.getEtcAnswerAt()).isEqualTo(original.getEtcAnswerAt());
+    }
+}

--- a/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qtm/util/EgovQustnrTmplatUtilityTest.java
+++ b/EgovQuestionnaire/src/test/java/egovframework/com/uss/olp/qtm/util/EgovQustnrTmplatUtilityTest.java
@@ -1,0 +1,88 @@
+package egovframework.com.uss.olp.qtm.util;
+
+import egovframework.com.uss.olp.qtm.entity.QustnrTmplat;
+import egovframework.com.uss.olp.qtm.service.QustnrTmplatVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovQustnrTmplatUtility 단위 테스트.
+ * Spring 컨텍스트 없이 설문 템플릿 변환 유틸리티 메서드를 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovQustnrTmplatUtilityTest {
+
+    @Test
+    @DisplayName("qustnrTmplatVOToEntity: VO 필드가 엔티티에 올바르게 복사된다")
+    void qustnrTmplatVOToEntity_fieldsAreCopiedCorrectly() {
+        QustnrTmplatVO vo = new QustnrTmplatVO();
+        vo.setQustnrTmplatId("TMPLAT-001");
+        vo.setQustnrTmplatTy("01");
+        vo.setQustnrTmplatDc("기본 설문 템플릿");
+        vo.setQustnrTmplatPathNm("/template/basic.png");
+
+        QustnrTmplat entity = EgovQustnrTmplatUtility.qustnrTmplatVOToEntity(vo);
+
+        assertThat(entity).isNotNull();
+        assertThat(entity.getQustnrTmplatId()).isEqualTo("TMPLAT-001");
+        assertThat(entity.getQustnrTmplatTy()).isEqualTo("01");
+        assertThat(entity.getQustnrTmplatDc()).isEqualTo("기본 설문 템플릿");
+        assertThat(entity.getQustnrTmplatPathNm()).isEqualTo("/template/basic.png");
+    }
+
+    @Test
+    @DisplayName("qustnrTmplatEntityToVO: 엔티티 필드가 VO에 올바르게 복사된다")
+    void qustnrTmplatEntityToVO_fieldsAreCopiedCorrectly() {
+        QustnrTmplat entity = new QustnrTmplat();
+        entity.setQustnrTmplatId("TMPLAT-002");
+        entity.setQustnrTmplatTy("02");
+        entity.setQustnrTmplatDc("커스텀 템플릿");
+        entity.setQustnrTmplatPathNm("/template/custom.png");
+        entity.setFrstRegisterId("USR001");
+        entity.setLastUpdusrId("USR002");
+        entity.setFrstRegistPnttm(LocalDateTime.of(2024, 3, 1, 9, 0));
+        entity.setLastUpdtPnttm(LocalDateTime.of(2024, 9, 1, 12, 0));
+
+        QustnrTmplatVO vo = EgovQustnrTmplatUtility.qustnrTmplatEntityToVO(entity);
+
+        assertThat(vo).isNotNull();
+        assertThat(vo.getQustnrTmplatId()).isEqualTo("TMPLAT-002");
+        assertThat(vo.getQustnrTmplatTy()).isEqualTo("02");
+        assertThat(vo.getQustnrTmplatDc()).isEqualTo("커스텀 템플릿");
+        assertThat(vo.getQustnrTmplatPathNm()).isEqualTo("/template/custom.png");
+        assertThat(vo.getFrstRegisterId()).isEqualTo("USR001");
+        assertThat(vo.getLastUpdusrId()).isEqualTo("USR002");
+    }
+
+    @Test
+    @DisplayName("qustnrTmplatEntityToVO: 엔티티의 이미지 바이트가 VO에 복사된다")
+    void qustnrTmplatEntityToVO_imageByteCopied() {
+        byte[] imageBytes = new byte[]{0x01, 0x02, 0x03};
+        QustnrTmplat entity = new QustnrTmplat();
+        entity.setQustnrTmplatId("TMPLAT-003");
+        entity.setQustnrTmplatImageInfo(imageBytes);
+
+        QustnrTmplatVO vo = EgovQustnrTmplatUtility.qustnrTmplatEntityToVO(entity);
+
+        assertThat(vo.getQustnrTmplatImageByte()).isEqualTo(imageBytes);
+    }
+
+    @Test
+    @DisplayName("qustnrTmplatEntityToVO: 이미지가 null인 경우 VO의 이미지 바이트도 null이다")
+    void qustnrTmplatEntityToVO_nullImageHandledGracefully() {
+        QustnrTmplat entity = new QustnrTmplat();
+        entity.setQustnrTmplatId("TMPLAT-004");
+        entity.setQustnrTmplatImageInfo(null);
+
+        QustnrTmplatVO vo = EgovQustnrTmplatUtility.qustnrTmplatEntityToVO(entity);
+
+        assertThat(vo).isNotNull();
+        assertThat(vo.getQustnrTmplatImageByte()).isNull();
+    }
+}


### PR DESCRIPTION
설문 관리 모듈(qim, qtm) 유틸리티 클래스에 대한 순수 단위 테스트를 추가한다.

## 변경 내용

**EgovQusntrItemUtilityTest** (`uss.olp.qim.util`)
- `qustnrIemEntityToVO`: 엔티티 복합 키 필드가 VO에 올바르게 매핑되는지 검증
- `qustnrIemVOToEntity`: VO ID 필드가 엔티티 복합 키에 올바르게 설정되는지 검증
- 왕복 변환(VO→Entity→VO) 후 항목 내용 보존 검증

**EgovQustnrTmplatUtilityTest** (`uss.olp.qtm.util`)
- `qustnrTmplatVOToEntity`: VO 필드 복사 검증
- `qustnrTmplatEntityToVO`: 엔티티 필드 및 이미지 바이트 복사 검증
- 이미지 null 처리 검증

## 테스트 환경

Spring 컨텍스트, DB, Eureka 불필요. `@ExtendWith(MockitoExtension.class)` 순수 단위 테스트.

```
Tests run: 7, Failures: 0, Errors: 0, Skipped: 0
```

## 체크리스트

- [x] 단일 주제만 다룸 (프로덕션 코드 변경 없음)
- [x] 기존 동작에 영향 없음
- [x] 테스트 통과 확인 (로컬 `mvn -pl EgovQuestionnaire test`)