### PR TITLE
[test][EgovMobileId] Base64Util/MipErrorEnum 단위 테스트 신설

### DIFF
--- a/EgovMobileId/src/test/java/egovframework/com/mip/mva/sp/comm/enums/MipErrorEnumTest.java
+++ b/EgovMobileId/src/test/java/egovframework/com/mip/mva/sp/comm/enums/MipErrorEnumTest.java
@@ -1,0 +1,81 @@
+package egovframework.com.mip.mva.sp.comm.enums;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @Project 모바일 운전면허증 서비스 구축 사업
+ * @PackageName egovframework.com.mip.mva.sp.comm.enums
+ * @FileName MipErrorEnumTest.java
+ * @Description MipErrorEnum 단위 테스트
+ *
+ * <pre>
+ * ==================================================
+ * DATE            AUTHOR           NOTE
+ * ==================================================
+ * 2026. 5. 20.    박성완           최초생성
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+class MipErrorEnumTest {
+
+    @Test
+    @DisplayName("getCode/getMsg: SP_MISSING_MANDATORY_ITEM은 코드 10002, 메시지 'missing mandatory item'이다")
+    void spMissingMandatoryItem_codeAndMsg() {
+        MipErrorEnum e = MipErrorEnum.SP_MISSING_MANDATORY_ITEM;
+
+        assertThat(e.getCode()).isEqualTo(10002);
+        assertThat(e.getMsg()).isEqualTo("missing mandatory item");
+    }
+
+    @Test
+    @DisplayName("getEnum: 코드 10001로 SP_UNEXPECTED_MSG_FORMAT을 조회할 수 있다")
+    void getEnum_knownCode_returnsCorrectEnum() {
+        MipErrorEnum result = MipErrorEnum.getEnum(10001);
+
+        assertThat(result).isNotNull();
+        assertThat(result).isEqualTo(MipErrorEnum.SP_UNEXPECTED_MSG_FORMAT);
+    }
+
+    @Test
+    @DisplayName("getEnum: 존재하지 않는 코드는 null을 반환한다")
+    void getEnum_unknownCode_returnsNull() {
+        MipErrorEnum result = MipErrorEnum.getEnum(99998);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("getEnum: UNKNOWN_ERROR(99999)를 코드로 조회할 수 있다")
+    void getEnum_unknownError_returnsEnum() {
+        MipErrorEnum result = MipErrorEnum.getEnum(99999);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getMsg()).isEqualTo("Unknown error");
+    }
+
+    @Test
+    @DisplayName("getCode: 모든 Enum 항목의 코드값이 null이 아니다")
+    void allEnumValues_codeNotNull() {
+        for (MipErrorEnum e : MipErrorEnum.values()) {
+            assertThat(e.getCode())
+                    .as("코드가 null인 항목: %s", e.name())
+                    .isNotNull();
+        }
+    }
+
+    @Test
+    @DisplayName("getMsg: 모든 Enum 항목의 메시지가 null이 아니고 비어있지 않다")
+    void allEnumValues_msgNotNullOrEmpty() {
+        for (MipErrorEnum e : MipErrorEnum.values()) {
+            assertThat(e.getMsg())
+                    .as("메시지가 비어있는 항목: %s", e.name())
+                    .isNotNull()
+                    .isNotEmpty();
+        }
+    }
+}

--- a/EgovMobileId/src/test/java/egovframework/com/mip/mva/sp/comm/util/Base64UtilTest.java
+++ b/EgovMobileId/src/test/java/egovframework/com/mip/mva/sp/comm/util/Base64UtilTest.java
@@ -1,0 +1,74 @@
+package egovframework.com.mip.mva.sp.comm.util;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @Project 모바일 운전면허증 서비스 구축 사업
+ * @PackageName egovframework.com.mip.mva.sp.comm.util
+ * @FileName Base64UtilTest.java
+ * @Description Base64Util 단위 테스트
+ *
+ * <pre>
+ * ==================================================
+ * DATE            AUTHOR           NOTE
+ * ==================================================
+ * 2026. 5. 20.    박성완           최초생성
+ * </pre>
+ */
+@ExtendWith(MockitoExtension.class)
+class Base64UtilTest {
+
+    @Test
+    @DisplayName("encode(String): 문자열을 Base64 URL 인코딩한 결과가 null이 아니고 비어있지 않다")
+    void encode_string_returnsNonEmptyBase64() {
+        String encoded = Base64Util.encode("hello");
+
+        assertThat(encoded).isNotNull().isNotEmpty();
+    }
+
+    @Test
+    @DisplayName("encode(String) → decode: 인코딩 후 디코딩하면 원래 문자열과 동일하다")
+    void encode_then_decode_returnsOriginal() {
+        String original = "mobile-id-test-value";
+
+        String encoded = Base64Util.encode(original);
+        String decoded = Base64Util.decode(encoded);
+
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("encode(byte[]) → decodeToByte: 바이트 배열 인코딩 후 디코딩하면 원본과 동일하다")
+    void encode_bytes_then_decodeToByte_returnsOriginal() {
+        byte[] original = "trxcode-payload".getBytes();
+
+        String encoded = Base64Util.encode(original);
+        byte[] decoded = Base64Util.decodeToByte(encoded);
+
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("encode: 빈 문자열도 정상적으로 인코딩·디코딩된다")
+    void encode_emptyString_roundTrip() {
+        String original = "";
+
+        String encoded = Base64Util.encode(original);
+        String decoded = Base64Util.decode(encoded);
+
+        assertThat(decoded).isEqualTo(original);
+    }
+
+    @Test
+    @DisplayName("encode(String): 반환값에 URL-unsafe 문자(+, /)가 포함되지 않는다")
+    void encode_string_usesUrlSafeAlphabet() {
+        String encoded = Base64Util.encode("any test input 12345!@#");
+
+        assertThat(encoded).doesNotContain("+", "/");
+    }
+}


### PR DESCRIPTION
## 변경 사유
EgovMobileId 모듈에 테스트가 없어 회귀 방어가 부재. 가장 결정적이고 단순한 단위(Base64 변환, ErrorEnum)부터 핀.

(동일 패턴 완료 PR: #12 EgovBoard, #13 EgovLogin, #14 EgovMain, #15 EgovQuestionnaire, #16 EgovCmmnCode)

## 변경 내용
- `Base64UtilTest`: encode/decode 라운드트립, URL-safe 알파벳, 빈 입력 처리
- `MipErrorEnumTest`: enum 값 조회 및 에러 메시지 해상

## 영향 범위
- production 코드 변경 없음
- 외부 서비스(DB/Eureka/Config) 접근 없음 — 순수 JUnit 5 + AssertJ

## 체크리스트
- [x] 단일 주제 (EgovMobileId 최초 단위 테스트)
- [x] 5.0.x 브랜치 대상
- [x] production 미변경