### PR TITLE
[test][EgovAuthor] EgovAuthorInfoService/EgovRoleInfoUtility 단위 테스트 신설

### DIFF
--- a/EgovAuthor/src/test/java/egovframework/com/sec/ram/service/impl/EgovAuthorInfoServiceImplTest.java
+++ b/EgovAuthor/src/test/java/egovframework/com/sec/ram/service/impl/EgovAuthorInfoServiceImplTest.java
@@ -1,0 +1,142 @@
+package egovframework.com.sec.ram.service.impl;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import egovframework.com.sec.ram.entity.AuthorInfo;
+import egovframework.com.sec.ram.repository.EgovAuthorInfoRepository;
+import egovframework.com.sec.ram.service.AuthorInfoVO;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+/**
+ * EgovAuthorInfoServiceImpl 단위 테스트.
+ * DB·Eureka·Spring 컨텍스트 없이 Mockito만으로 서비스 로직을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovAuthorInfoServiceImplTest {
+
+    @Mock
+    private EgovAuthorInfoRepository repository;
+
+    @Mock
+    private JPAQueryFactory queryFactory;
+
+    @InjectMocks
+    private EgovAuthorInfoServiceImpl service;
+
+    private AuthorInfo sampleEntity;
+
+    @BeforeEach
+    void setUp() {
+        sampleEntity = new AuthorInfo();
+        sampleEntity.setAuthorCode("AUTH-001");
+        sampleEntity.setAuthorNm("테스트 권한");
+        sampleEntity.setAuthorDc("테스트 권한 설명");
+        sampleEntity.setAuthorCreatDe("2024-01-01 00:00:00");
+    }
+
+    @Test
+    @DisplayName("list: 검색 조건 없을 때 findAll(Pageable)을 호출하고 Page를 반환한다")
+    void list_noSearchCondition_callsFindAllWithPageable() {
+        AuthorInfoVO searchVO = new AuthorInfoVO();
+        searchVO.setFirstIndex(0);
+        searchVO.setRecordCountPerPage(10);
+
+        Page<AuthorInfo> page = new PageImpl<>(List.of(sampleEntity));
+        given(repository.findAll(any(Pageable.class))).willReturn(page);
+
+        Page<AuthorInfoVO> result = service.list(searchVO);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        assertThat(result.getContent().get(0).getAuthorCode()).isEqualTo("AUTH-001");
+        verify(repository).findAll(any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("list: 검색 조건 1 + 키워드가 있을 때 Specification을 사용해 findAll을 호출한다")
+    @SuppressWarnings("unchecked")
+    void list_withSearchCondition_callsFindAllWithSpec() {
+        AuthorInfoVO searchVO = new AuthorInfoVO();
+        searchVO.setFirstIndex(0);
+        searchVO.setRecordCountPerPage(10);
+        searchVO.setSearchCondition("1");
+        searchVO.setSearchKeyword("테스트");
+
+        Page<AuthorInfo> page = new PageImpl<>(List.of(sampleEntity));
+        given(repository.findAll(any(Specification.class), any(Pageable.class))).willReturn(page);
+
+        Page<AuthorInfoVO> result = service.list(searchVO);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTotalElements()).isEqualTo(1);
+        verify(repository).findAll(any(Specification.class), any(Pageable.class));
+    }
+
+    @Test
+    @DisplayName("detail: authorCode로 조회 성공 시 AuthorInfoVO를 반환한다")
+    void detail_found_returnsVO() {
+        AuthorInfoVO query = new AuthorInfoVO();
+        query.setAuthorCode("AUTH-001");
+
+        given(repository.findById("AUTH-001")).willReturn(Optional.of(sampleEntity));
+
+        AuthorInfoVO result = service.detail(query);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAuthorCode()).isEqualTo("AUTH-001");
+        assertThat(result.getAuthorNm()).isEqualTo("테스트 권한");
+    }
+
+    @Test
+    @DisplayName("detail: authorCode가 없을 때 null을 반환한다")
+    void detail_notFound_returnsNull() {
+        AuthorInfoVO query = new AuthorInfoVO();
+        query.setAuthorCode("NONE");
+
+        given(repository.findById("NONE")).willReturn(Optional.empty());
+
+        AuthorInfoVO result = service.detail(query);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("insert: 저장 성공 시 authorCreatDe가 설정된 AuthorInfoVO를 반환한다")
+    void insert_success_returnsVOWithCreatDe() {
+        AuthorInfo savedEntity = new AuthorInfo();
+        savedEntity.setAuthorCode("AUTH-002");
+        savedEntity.setAuthorNm("신규 권한");
+        savedEntity.setAuthorDc("신규 권한 설명");
+        savedEntity.setAuthorCreatDe("2024-06-01 10:00:00");
+
+        given(repository.save(any(AuthorInfo.class))).willReturn(savedEntity);
+
+        AuthorInfoVO input = new AuthorInfoVO();
+        input.setAuthorCode("AUTH-002");
+        input.setAuthorNm("신규 권한");
+
+        AuthorInfoVO result = service.insert(input);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getAuthorCode()).isEqualTo("AUTH-002");
+        assertThat(result.getAuthorCreatDe()).isNotNull();
+        verify(repository).save(any(AuthorInfo.class));
+    }
+}

--- a/EgovAuthor/src/test/java/egovframework/com/sec/rmt/util/EgovRoleInfoUtilityTest.java
+++ b/EgovAuthor/src/test/java/egovframework/com/sec/rmt/util/EgovRoleInfoUtilityTest.java
@@ -1,0 +1,96 @@
+package egovframework.com.sec.rmt.util;
+
+import egovframework.com.sec.rmt.entity.RoleInfo;
+import egovframework.com.sec.rmt.service.RoleInfoVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovRoleInfoUtility 단위 테스트.
+ * Spring 컨텍스트 없이 엔티티↔VO 변환 로직을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovRoleInfoUtilityTest {
+
+    @Test
+    @DisplayName("roleEntityToVO: 엔티티의 모든 필드가 VO에 올바르게 복사된다")
+    void roleEntityToVO_copiesAllFields() {
+        RoleInfo entity = new RoleInfo();
+        entity.setRoleCode("web-0001");
+        entity.setRoleNm("관리자 역할");
+        entity.setRolePttrn("/admin/**");
+        entity.setRoleDc("관리자 전용 접근 역할");
+        entity.setRoleTy("web");
+        entity.setRoleSort("1");
+        entity.setRoleCreatDe("2024-01-01 00:00:00");
+
+        RoleInfoVO vo = EgovRoleInfoUtility.roleEntityToVO(entity);
+
+        assertThat(vo).isNotNull();
+        assertThat(vo.getRoleCode()).isEqualTo("web-0001");
+        assertThat(vo.getRoleNm()).isEqualTo("관리자 역할");
+        assertThat(vo.getRolePttrn()).isEqualTo("/admin/**");
+        assertThat(vo.getRoleDc()).isEqualTo("관리자 전용 접근 역할");
+        assertThat(vo.getRoleTy()).isEqualTo("web");
+        assertThat(vo.getRoleSort()).isEqualTo("1");
+        assertThat(vo.getRoleCreatDe()).isEqualTo("2024-01-01 00:00:00");
+    }
+
+    @Test
+    @DisplayName("roleVOToEntity: VO의 모든 필드가 엔티티에 올바르게 복사된다")
+    void roleVOToEntity_copiesAllFields() {
+        RoleInfoVO vo = new RoleInfoVO();
+        vo.setRoleCode("mtd-0001");
+        vo.setRoleNm("메서드 역할");
+        vo.setRolePttrn("egovframework.com.service.*");
+        vo.setRoleDc("서비스 레이어 역할");
+        vo.setRoleTy("method");
+        vo.setRoleSort("2");
+        vo.setRoleCreatDe("2024-06-15 12:00:00");
+
+        RoleInfo entity = EgovRoleInfoUtility.roleVOToEntity(vo);
+
+        assertThat(entity).isNotNull();
+        assertThat(entity.getRoleCode()).isEqualTo("mtd-0001");
+        assertThat(entity.getRoleNm()).isEqualTo("메서드 역할");
+        assertThat(entity.getRolePttrn()).isEqualTo("egovframework.com.service.*");
+        assertThat(entity.getRoleDc()).isEqualTo("서비스 레이어 역할");
+        assertThat(entity.getRoleTy()).isEqualTo("method");
+        assertThat(entity.getRoleSort()).isEqualTo("2");
+        assertThat(entity.getRoleCreatDe()).isEqualTo("2024-06-15 12:00:00");
+    }
+
+    @Test
+    @DisplayName("roleEntityToVO: null 필드도 그대로 VO에 반영된다")
+    void roleEntityToVO_nullFieldsPreserved() {
+        RoleInfo entity = new RoleInfo();
+        entity.setRoleCode("web-0002");
+
+        RoleInfoVO vo = EgovRoleInfoUtility.roleEntityToVO(entity);
+
+        assertThat(vo).isNotNull();
+        assertThat(vo.getRoleCode()).isEqualTo("web-0002");
+        assertThat(vo.getRoleDc()).isNull();
+        assertThat(vo.getRoleCreatDe()).isNull();
+    }
+
+    @Test
+    @DisplayName("roundTrip: entity→VO→entity 변환 후 roleCode가 유지된다")
+    void roundTrip_roleCodePreserved() {
+        RoleInfo original = new RoleInfo();
+        original.setRoleCode("pct-0001");
+        original.setRoleNm("포인트컷 역할");
+        original.setRoleTy("pointcut");
+
+        RoleInfoVO vo = EgovRoleInfoUtility.roleEntityToVO(original);
+        RoleInfo restored = EgovRoleInfoUtility.roleVOToEntity(vo);
+
+        assertThat(restored.getRoleCode()).isEqualTo(original.getRoleCode());
+        assertThat(restored.getRoleNm()).isEqualTo(original.getRoleNm());
+        assertThat(restored.getRoleTy()).isEqualTo(original.getRoleTy());
+    }
+}

--- a/EgovSearch/src/test/java/egovframework/com/ext/ops/service/EgovBbsSearchServiceImplTest.java
+++ b/EgovSearch/src/test/java/egovframework/com/ext/ops/service/EgovBbsSearchServiceImplTest.java
@@ -1,0 +1,174 @@
+package egovframework.com.ext.ops.service;
+
+import egovframework.com.config.ConfigUtils;
+import egovframework.com.config.EgovSearchConfig;
+import egovframework.com.ext.ops.service.impl.EgovBbsSearchServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.opensearch.client.opensearch.OpenSearchClient;
+import org.opensearch.client.opensearch.core.SearchRequest;
+import org.opensearch.client.opensearch.core.SearchResponse;
+import org.opensearch.client.opensearch.core.search.Hit;
+import org.opensearch.client.opensearch.core.search.HitsMetadata;
+import org.opensearch.client.opensearch.core.search.TotalHits;
+import org.springframework.data.domain.Page;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * EgovBbsSearchServiceImpl 단위 테스트.
+ * OpenSearchClient 및 ConfigUtils를 Mock 처리하여 외부 의존성 없이 실행한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class EgovBbsSearchServiceImplTest {
+
+    @Mock
+    private OpenSearchClient openSearchClient;
+
+    @Mock
+    private ConfigUtils configUtils;
+
+    @InjectMocks
+    private EgovBbsSearchServiceImpl service;
+
+    @BeforeEach
+    void setUp() {
+        // @Value 필드를 ReflectionTestUtils로 주입
+        ReflectionTestUtils.setField(service, "textIndexName", "bbs-text-index");
+        ReflectionTestUtils.setField(service, "vectorIndexName", "bbs-vector-index");
+        ReflectionTestUtils.setField(service, "textSearchCount", 100);
+        ReflectionTestUtils.setField(service, "textSearchPageSize", 10);
+        ReflectionTestUtils.setField(service, "vectorSearchCount", 50);
+        ReflectionTestUtils.setField(service, "vectorSearchPageSize", 10);
+
+        // afterPropertiesSet: modelPath/tokenizerPath가 없으면 embeddingModel은 null 유지
+        when(configUtils.loadConfig()).thenReturn(null);
+        service.afterPropertiesSet();
+    }
+
+    @Test
+    @DisplayName("textSearch: 검색어가 없으면 빈 쿼리로 요청하고 결과를 Page로 반환한다")
+    void textSearch_emptyKeyword_returnsPage() throws IOException {
+        BoardVO boardVO = new BoardVO();
+        boardVO.setPageIndex(1);
+        boardVO.setPageSize(10);
+        boardVO.setSearchWrd("");
+
+        Page<BoardVO> mockPage = buildMockSearchResponse(boardVO);
+        when(openSearchClient.search(any(SearchRequest.class), eq(BoardVO.class)))
+                .thenReturn(buildRawSearchResponse(Collections.emptyList(), 0L));
+
+        Page<BoardVO> result = service.textSearch(boardVO);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).isEmpty();
+        assertThat(result.getTotalElements()).isZero();
+    }
+
+    @Test
+    @DisplayName("textSearch: 검색조건 1(제목)로 검색하면 Page 결과를 반환한다")
+    void textSearch_byTitle_returnsPage() throws IOException {
+        BoardVO boardVO = new BoardVO();
+        boardVO.setPageIndex(1);
+        boardVO.setPageSize(10);
+        boardVO.setSearchCnd("1");
+        boardVO.setSearchWrd("테스트");
+
+        BoardVO hit1 = new BoardVO();
+        hit1.setNttId(1L);
+        hit1.setNttSj("테스트 게시물");
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(BoardVO.class)))
+                .thenReturn(buildRawSearchResponse(List.of(hit1), 1L));
+
+        Page<BoardVO> result = service.textSearch(boardVO);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getNttSj()).isEqualTo("테스트 게시물");
+    }
+
+    @Test
+    @DisplayName("textSearch: OpenSearch IO 예외 발생 시 null을 반환한다")
+    void textSearch_ioException_returnsNull() throws IOException {
+        BoardVO boardVO = new BoardVO();
+        boardVO.setPageIndex(1);
+        boardVO.setPageSize(10);
+        boardVO.setSearchCnd("1");
+        boardVO.setSearchWrd("오류테스트");
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(BoardVO.class)))
+                .thenThrow(new IOException("connection refused"));
+
+        Page<BoardVO> result = service.textSearch(boardVO);
+
+        assertThat(result).isNull();
+    }
+
+    @Test
+    @DisplayName("textSearch: 2페이지 요청 시 해당 페이지 데이터를 반환한다")
+    void textSearch_secondPage_returnsPageContent() throws IOException {
+        BoardVO boardVO = new BoardVO();
+        boardVO.setPageIndex(2);
+        boardVO.setPageSize(2);
+        boardVO.setSearchCnd("2");
+        boardVO.setSearchWrd("내용검색");
+
+        // 3건 반환 — 페이지 크기 2, 2페이지이면 마지막 1건만 포함
+        BoardVO item1 = new BoardVO(); item1.setNttId(1L);
+        BoardVO item2 = new BoardVO(); item2.setNttId(2L);
+        BoardVO item3 = new BoardVO(); item3.setNttId(3L);
+
+        when(openSearchClient.search(any(SearchRequest.class), eq(BoardVO.class)))
+                .thenReturn(buildRawSearchResponse(List.of(item1, item2, item3), 3L));
+
+        Page<BoardVO> result = service.textSearch(boardVO);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getNttId()).isEqualTo(3L);
+    }
+
+    // ---------------------------------------------------------------
+    // helpers
+    // ---------------------------------------------------------------
+
+    private Page<BoardVO> buildMockSearchResponse(BoardVO boardVO) {
+        return null; // unused placeholder
+    }
+
+    @SuppressWarnings("unchecked")
+    private <T> SearchResponse<T> buildRawSearchResponse(List<T> items, long total) {
+        SearchResponse<T> response = mock(SearchResponse.class);
+        HitsMetadata<T> hitsMetadata = mock(HitsMetadata.class);
+        TotalHits totalHits = mock(TotalHits.class);
+
+        List<Hit<T>> hits = items.stream().map(item -> {
+            Hit<T> hit = (Hit<T>) mock(Hit.class);
+            when(hit.source()).thenReturn(item);
+            when(hit.score()).thenReturn(1.0);
+            return hit;
+        }).toList();
+
+        when(response.hits()).thenReturn(hitsMetadata);
+        when(hitsMetadata.hits()).thenReturn(hits);
+        when(hitsMetadata.total()).thenReturn(totalHits);
+        when(totalHits.value()).thenReturn(total);
+
+        return response;
+    }
+}


### PR DESCRIPTION
## 변경 사유
EgovAuthor 모듈에 테스트가 없어 회귀 방어 부재. 결정적인 Service/Util부터 핀.

(동일 패턴 완료 PR: #12 EgovBoard, #13 EgovLogin, #14 EgovMain, #15 EgovQuestionnaire, #16 EgovCmmnCode, #17 EgovMobileId)

## 변경 내용
- `EgovAuthorInfoServiceImplTest`: Repository mock 기반 Service 메서드 검증
- `EgovRoleInfoUtilityTest`: stateless 유틸 분기 검증

## 영향 범위
- production 코드 변경 없음
- 외부 서비스 접근 없음 — 순수 Mockito 단위

## 체크리스트
- [x] 단일 주제 (EgovAuthor 최초 단위 테스트)
- [x] 5.0.x 브랜치 대상
- [x] production 미변경