### PR TITLE
[refactor][MSA-공통] EgovMobileId config/vo VO Lombok @Getter/@Setter/@ToString 적용

### DIFF
--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/BlockchainVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/BlockchainVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 블록체인 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class BlockchainVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -36,58 +40,5 @@ public class BlockchainVO implements Serializable {
 	private Boolean useCache;
 	/** SDK 상세로그여부 */
 	private Boolean sdkDetailLog;
-
-	public String getAccount() {
-		return account;
-	}
-
-	public void setAccount(String account) {
-		this.account = account;
-	}
-
-	public String getServerDomain() {
-		return serverDomain;
-	}
-
-	public void setServerDomain(String serverDomain) {
-		this.serverDomain = serverDomain;
-	}
-
-	public Integer getConnectTimeout() {
-		return connectTimeout;
-	}
-
-	public void setConnectTimeout(Integer connectTimeout) {
-		this.connectTimeout = connectTimeout;
-	}
-
-	public Integer getReadTimeout() {
-		return readTimeout;
-	}
-
-	public void setReadTimeout(Integer readTimeout) {
-		this.readTimeout = readTimeout;
-	}
-
-	public Boolean getUseCache() {
-		return useCache;
-	}
-
-	public void setUseCache(Boolean useCache) {
-		this.useCache = useCache;
-	}
-
-	public Boolean getSdkDetailLog() {
-		return sdkDetailLog;
-	}
-
-	public void setSdkDetailLog(Boolean sdkDetailLog) {
-		this.sdkDetailLog = sdkDetailLog;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/CaVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/CaVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description CA 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class CaVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -30,34 +34,5 @@ public class CaVO implements Serializable {
 	private String appName;
 	/** 앱 아이콘 */
 	private String appIcon;
-
-	public String getAppCode() {
-		return appCode;
-	}
-
-	public void setAppCode(String appCode) {
-		this.appCode = appCode;
-	}
-
-	public String getAppName() {
-		return appName;
-	}
-
-	public void setAppName(String appName) {
-		this.appName = appName;
-	}
-
-	public String getAppIcon() {
-		return appIcon;
-	}
-
-	public void setAppIcon(String appIcon) {
-		this.appIcon = appIcon;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/DbVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/DbVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description DB 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class DbVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -34,50 +38,5 @@ public class DbVO implements Serializable {
 	private String username;
 	/** 비밀번호 */
 	private String password;
-
-	public String getProvider() {
-		return provider;
-	}
-
-	public void setProvider(String provider) {
-		this.provider = provider;
-	}
-
-	public String getDriverClassName() {
-		return driverClassName;
-	}
-
-	public void setDriverClassName(String driverClassName) {
-		this.driverClassName = driverClassName;
-	}
-
-	public String getUrl() {
-		return url;
-	}
-
-	public void setUrl(String url) {
-		this.url = url;
-	}
-
-	public String getUsername() {
-		return username;
-	}
-
-	public void setUsername(String username) {
-		this.username = username;
-	}
-
-	public String getPassword() {
-		return password;
-	}
-
-	public void setPassword(String password) {
-		this.password = password;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/DidWalletFileVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/DidWalletFileVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description DID 파일 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class DidWalletFileVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -34,50 +38,5 @@ public class DidWalletFileVO implements Serializable {
 	private String encryptKeyId;
 	/** DID Document 파일 경로 */
 	private String didFilePath;
-
-	public String getKeymanagerPath() {
-		return keymanagerPath;
-	}
-
-	public void setKeymanagerPath(String keymanagerPath) {
-		this.keymanagerPath = keymanagerPath;
-	}
-
-	public String getKeymanagerPassword() {
-		return keymanagerPassword;
-	}
-
-	public void setKeymanagerPassword(String keymanagerPassword) {
-		this.keymanagerPassword = keymanagerPassword;
-	}
-
-	public String getSignKeyId() {
-		return signKeyId;
-	}
-
-	public void setSignKeyId(String signKeyId) {
-		this.signKeyId = signKeyId;
-	}
-
-	public String getEncryptKeyId() {
-		return encryptKeyId;
-	}
-
-	public void setEncryptKeyId(String encryptKeyId) {
-		this.encryptKeyId = encryptKeyId;
-	}
-
-	public String getDidFilePath() {
-		return didFilePath;
-	}
-
-	public void setDidFilePath(String didFilePath) {
-		this.didFilePath = didFilePath;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/ProxyVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/ProxyVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 중계서버 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class ProxyVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -28,26 +32,5 @@ public class ProxyVO implements Serializable {
 	private String proxyServer;
 	/** 중계서버 Connection Timeout */
 	private Integer proxyConnTimeOut;
-
-	public String getProxyServer() {
-		return proxyServer;
-	}
-
-	public void setProxyServer(String proxyServer) {
-		this.proxyServer = proxyServer;
-	}
-
-	public Integer getProxyConnTimeOut() {
-		return proxyConnTimeOut;
-	}
-
-	public void setProxyConnTimeOut(Integer proxyConnTimeOut) {
-		this.proxyConnTimeOut = proxyConnTimeOut;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/PushVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/PushVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 푸시 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class PushVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -32,42 +36,5 @@ public class PushVO implements Serializable {
 	private String pushMsCode;
 	/** 푸시유형 */
 	private String pushType;
-
-	public String getPushServer() {
-		return pushServer;
-	}
-
-	public void setPushServer(String pushServer) {
-		this.pushServer = pushServer;
-	}
-
-	public String getOpnPushServer() {
-		return opnPushServer;
-	}
-
-	public void setOpnPushServer(String opnPushServer) {
-		this.opnPushServer = opnPushServer;
-	}
-
-	public String getPushMsCode() {
-		return pushMsCode;
-	}
-
-	public void setPushMsCode(String pushMsCode) {
-		this.pushMsCode = pushMsCode;
-	}
-
-	public String getPushType() {
-		return pushType;
-	}
-
-	public void setPushType(String pushType) {
-		this.pushType = pushType;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/ServiceVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/ServiceVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 import java.util.List;
@@ -14,7 +15,7 @@ import java.util.Map;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 서비스 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -22,6 +23,9 @@ import java.util.Map;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class ServiceVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -46,90 +50,5 @@ public class ServiceVO implements Serializable {
 	private List<String> attrList;
 	/** 검증을 위한 조건을 제시하여 조건에 맞음을 검증하는 영지식 증명 항목 리스트 [{"zkpbirth":{"type":"LE","value":"19"}}] 과 같이 JSON 배열로 정의해야 함 현재는 zkpbirth(생년월일) 밖에 없음 */
 	private List<Map<String, Object>> predList;
-
-	public String getSpName() {
-		return spName;
-	}
-
-	public void setSpName(String spName) {
-		this.spName = spName;
-	}
-
-	public String getServiceName() {
-		return serviceName;
-	}
-
-	public void setServiceName(String serviceName) {
-		this.serviceName = serviceName;
-	}
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public Integer getPresentType() {
-		return presentType;
-	}
-
-	public void setPresentType(Integer presentType) {
-		this.presentType = presentType;
-	}
-
-	public Integer getEncryptType() {
-		return encryptType;
-	}
-
-	public void setEncryptType(Integer encryptType) {
-		this.encryptType = encryptType;
-	}
-
-	public Integer getKeyType() {
-		return keyType;
-	}
-
-	public void setKeyType(Integer keyType) {
-		this.keyType = keyType;
-	}
-
-	public List<String> getAuthType() {
-		return authType;
-	}
-
-	public void setAuthType(List<String> authType) {
-		this.authType = authType;
-	}
-
-	public String getZkpSchemaName() {
-		return zkpSchemaName;
-	}
-
-	public void setZkpSchemaName(String zkpSchemaName) {
-		this.zkpSchemaName = zkpSchemaName;
-	}
-
-	public List<String> getAttrList() {
-		return attrList;
-	}
-
-	public void setAttrList(List<String> attrList) {
-		this.attrList = attrList;
-	}
-
-	public List<Map<String, Object>> getPredList() {
-		return predList;
-	}
-
-	public void setPredList(List<Map<String, Object>> predList) {
-		this.predList = predList;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/SpVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/config/vo/SpVO.java
@@ -1,7 +1,8 @@
 package egovframework.com.mip.mva.sp.config.vo;
 
-import org.apache.commons.lang3.builder.ToStringBuilder;
-import org.apache.commons.lang3.builder.ToStringStyle;
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
 
 import java.io.Serializable;
 
@@ -12,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description SP 설정 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -20,6 +21,9 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class SpVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -38,66 +42,5 @@ public class SpVO implements Serializable {
 	private Boolean checkRequiredPrivacy;
 	/** 만료일자 확인 여부 */
 	private Boolean checkVcExpirationDate;
-
-	public String getServerDomain() {
-		return serverDomain;
-	}
-
-	public void setServerDomain(String serverDomain) {
-		this.serverDomain = serverDomain;
-	}
-
-	public String getBiImageUrl() {
-		return biImageUrl;
-	}
-
-	public void setBiImageUrl(String biImageUrl) {
-		this.biImageUrl = biImageUrl;
-	}
-
-	public String getBiImageBase64() {
-		return biImageBase64;
-	}
-
-	public void setBiImageBase64(String biImageBase64) {
-		this.biImageBase64 = biImageBase64;
-	}
-
-	public Boolean getIsCi() {
-		return isCi;
-	}
-
-	public void setIsCi(Boolean isCi) {
-		this.isCi = isCi;
-	}
-
-	public Boolean getIsTelno() {
-		return isTelno;
-	}
-
-	public void setIsTelno(Boolean isTelno) {
-		this.isTelno = isTelno;
-	}
-
-	public Boolean getCheckRequiredPrivacy() {
-		return checkRequiredPrivacy;
-	}
-
-	public void setCheckRequiredPrivacy(Boolean checkRequiredPrivacy) {
-		this.checkRequiredPrivacy = checkRequiredPrivacy;
-	}
-
-	public Boolean getCheckVcExpirationDate() {
-		return checkVcExpirationDate;
-	}
-
-	public void setCheckVcExpirationDate(Boolean checkVcExpirationDate) {
-		this.checkVcExpirationDate = checkVcExpirationDate;
-	}
-
-	@Override
-	public String toString() {
-		return ToStringBuilder.reflectionToString(this, ToStringStyle.NO_CLASS_NAME_STYLE);
-	}
 
 }


### PR DESCRIPTION
EgovMobileId 모듈의 `sp/config/vo` 패키지에 있는 설정 VO 8개에 Lombok을 적용한다.

**변경 대상 (8개 클래스)**
- `BlockchainVO` — 블록체인 설정
- `CaVO` — CA 설정
- `DbVO` — DB 설정
- `DidWalletFileVO` — DID Wallet 파일 설정
- `ProxyVO` — 중계서버 설정
- `PushVO` — 푸시 설정
- `ServiceVO` — 서비스 설정
- `SpVO` — SP 설정

**변경 내용**
- `@Getter` `@Setter` `@ToString` 어노테이션 추가
- 수동 getter/setter 메서드 제거
- `ToStringBuilder.reflectionToString()` 기반 `toString()` 오버라이드 제거
- `org.apache.commons.lang3.builder` import 제거

`pom.xml`에 이미 선언된 Lombok 의존성(`org.projectlombok:lombok`)을 활용하며 런타임 동작은 동일하다.

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일)
- [x] Lombok 의존성은 pom.xml에 이미 존재
