### PR TITLE
[refactor][EgovMobileId] comm/vo 패키지 VO 클래스 Lombok @Getter/@Setter 적용

### DIFF
--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/LicenseDriverVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/LicenseDriverVO.java
@@ -1,6 +1,9 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import com.raonsecure.omnione.core.data.iw.Unprotected;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -21,52 +24,51 @@ import java.util.Map;
  *
  * </pre>
  */
+@Getter
+@Setter
+@NoArgsConstructor
 public class LicenseDriverVO implements Serializable {
-	
+
 	private static final long serialVersionUID = 1L;
 
-    private String name;              // 이름
-    private String ihidnum;           // 주민등록번호
-    private String address;           // 주소
-    private String birth;             // 생년월일
-    private String dlphotoimage;      // 사진이미지
-    
-    private String dlno;              // 운전면허증번호
-    private String asort;             // 면허종별
-    private String inspctbegend;      // 적성검사시작종료일자
-    private String issude;            // 발급일자
-    private String locpanm;           // 지방경찰청명의
-    private String passwordsn;        // 암호일련번호
-    private String inorgdonnyn;       // 장기기증여부
-    private String lcnscndcdnm;       // 면허조건명
-    private String engnm;             // 영문이름
-    private String engsex;            // 성별
-    private String engbirth;          // 영문생년월일
-    private String engaddr;           // 영문주소
-    private String ci;				  // 연계 정보
+	private String name;              // 이름
+	private String ihidnum;           // 주민등록번호
+	private String address;           // 주소
+	private String birth;             // 생년월일
+	private String dlphotoimage;      // 사진이미지
 
-    public LicenseDriverVO() {
-    	
-    }
+	private String dlno;              // 운전면허증번호
+	private String asort;             // 면허종별
+	private String inspctbegend;      // 적성검사시작종료일자
+	private String issude;            // 발급일자
+	private String locpanm;           // 지방경찰청명의
+	private String passwordsn;        // 암호일련번호
+	private String inorgdonnyn;       // 장기기증여부
+	private String lcnscndcdnm;       // 면허조건명
+	private String engnm;             // 영문이름
+	private String engsex;            // 성별
+	private String engbirth;          // 영문생년월일
+	private String engaddr;           // 영문주소
+	private String ci;                // 연계 정보
 
-    /**
+	/**
 	 * Privacy 목록과 License VO를 매핑
-	 * 
+	 *
 	 * @MethodName mapFromList
 	 * @param privacy Privacy목록
 	 * @return LicenseDriverVO
 	 */
-    public LicenseDriverVO mapFromList(List<Unprotected> privacy) {
-    	LicenseDriverVO vo = new LicenseDriverVO();
-    	
-    	Map<String, String> map = new HashMap<>();
-		for(int i=0; i<privacy.size(); i++) {
+	public LicenseDriverVO mapFromList(List<Unprotected> privacy) {
+		LicenseDriverVO vo = new LicenseDriverVO();
+
+		Map<String, String> map = new HashMap<>();
+		for (int i = 0; i < privacy.size(); i++) {
 			map.put(
 				privacy.get(i).getType(),
 				privacy.get(i).getValue().equals("") ? null : privacy.get(i).getValue()
 			);
 		}
-		
+
 		vo.setName(map.get("name"));
 		vo.setIhidnum(map.get("ihidnum"));
 		vo.setDlphotoimage(map.get("dlphotoimage"));
@@ -85,62 +87,8 @@ public class LicenseDriverVO implements Serializable {
 		vo.setEngbirth(map.get("engbirth"));
 		vo.setEngaddr(map.get("engaddr"));
 		vo.setCi(map.get("ci"));
-        
-        return vo;
-    }
 
-    // Getter & Setter
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
+		return vo;
+	}
 
-    public String getIhidnum() { return ihidnum; }
-    public void setIhidnum(String ihidnum) { this.ihidnum = ihidnum; }
-
-    public String getDlphotoimage() { return dlphotoimage; }
-    public void setDlphotoimage(String dlphotoimage) { this.dlphotoimage = dlphotoimage; }
-
-    public String getAddress() { return address; }
-    public void setAddress(String address) { this.address = address; }
-
-    public String getBirth() { return birth; }
-    public void setBirth(String birth) { this.birth = birth; }
-
-    public String getDlno() { return dlno; }
-    public void setDlno(String dlno) { this.dlno = dlno; }
-
-    public String getAsort() { return asort; }
-    public void setAsort(String asort) { this.asort = asort; }
-
-    public String getInspctbegend() { return inspctbegend; }
-    public void setInspctbegend(String inspctbegend) { this.inspctbegend = inspctbegend; }
-
-    public String getIssude() { return issude; }
-    public void setIssude(String issude) { this.issude = issude; }
-
-    public String getLocpanm() { return locpanm; }
-    public void setLocpanm(String locpanm) { this.locpanm = locpanm; }
-
-    public String getPasswordsn() { return passwordsn; }
-    public void setPasswordsn(String passwordsn) { this.passwordsn = passwordsn; }
-
-    public String getInorgdonnyn() { return inorgdonnyn; }
-    public void setInorgdonnyn(String inorgdonnyn) { this.inorgdonnyn = inorgdonnyn; }
-
-    public String getLcnscndcdnm() { return lcnscndcdnm; }
-    public void setLcnscndcdnm(String lcnscndcdnm) { this.lcnscndcdnm = lcnscndcdnm; }
-
-    public String getEngnm() { return engnm; }
-    public void setEngnm(String engnm) { this.engnm = engnm; }
-
-    public String getEngsex() { return engsex; }
-    public void setEngsex(String engsex) { this.engsex = engsex; }
-
-    public String getEngbirth() { return engbirth; }
-    public void setEngbirth(String engbirth) { this.engbirth = engbirth; }
-
-    public String getEngaddr() { return engaddr; }
-    public void setEngaddr(String engaddr) { this.engaddr = engaddr; }
-    
-    public String getCi() { return ci; }
-    public void setCi(String ci) { this.ci = ci; }
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/LicenseExpatVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/LicenseExpatVO.java
@@ -1,6 +1,9 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import com.raonsecure.omnione.core.data.iw.Unprotected;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -21,145 +24,79 @@ import java.util.Map;
  *
  * </pre>
  */
+@Getter
+@Setter
+@NoArgsConstructor
 public class LicenseExpatVO implements Serializable {
-	
+
 	private static final long serialVersionUID = 1L;
 
-    private String name;              // 이름
-    private String ihidnum;           // 주민등록번호
-    private String address;           // 주소
-    private String birth;             // 생년월일
-    private String dlphotoimage;      // 사진이미지
-    
-    private String expatno;           // 재외국민번호
-    private String expatnosn;         // 재외국민번호 일련번호
-    private String rephonno;          // 대표 보훈번호
-    private String title;             // 타이틀
-    private String usrname;           // 영문 성
-    private String givennames;        // 영문 이름
-    private String passporttype;      // 종류
-    private String countrycode;       // 발행국
-    private String passportno;        // 여권번호
-    private String nationality;       // 국적
-    private String issude;            // 발급일
-    private String expirdate;         // 만료일
-    private String sex;               // 성별
-    private String bearersigna;       // 여권소지인의서명
-    private String authority;         // 발행관청
-    private String emblnm;            // 관할공관
-    private String ci;                // 연계정보
+	private String name;              // 이름
+	private String ihidnum;           // 주민등록번호
+	private String address;           // 주소
+	private String birth;             // 생년월일
+	private String dlphotoimage;      // 사진이미지
 
-    public LicenseExpatVO() {
-    }
+	private String expatno;           // 재외국민번호
+	private String expatnosn;         // 재외국민번호 일련번호
+	private String rephonno;          // 대표 보훈번호
+	private String title;             // 타이틀
+	private String usrname;           // 영문 성
+	private String givennames;        // 영문 이름
+	private String passporttype;      // 종류
+	private String countrycode;       // 발행국
+	private String passportno;        // 여권번호
+	private String nationality;       // 국적
+	private String issude;            // 발급일
+	private String expirdate;         // 만료일
+	private String sex;               // 성별
+	private String bearersigna;       // 여권소지인의서명
+	private String authority;         // 발행관청
+	private String emblnm;            // 관할공관
+	private String ci;                // 연계정보
 
-    /**
+	/**
 	 * Privacy 목록과 License VO를 매핑
-	 * 
+	 *
 	 * @MethodName mapFromList
 	 * @param privacy Privacy목록
 	 * @return LicenseExpatVO
 	 */
-    public LicenseExpatVO mapFromList(List<Unprotected> privacy) {
-        LicenseExpatVO vo = new LicenseExpatVO();
+	public LicenseExpatVO mapFromList(List<Unprotected> privacy) {
+		LicenseExpatVO vo = new LicenseExpatVO();
 
-        Map<String, String> map = new HashMap<>();
-        for (int i = 0; i < privacy.size(); i++) {
-            map.put(
-        		privacy.get(i).getType(),
-        		privacy.get(i).getValue().equals("") ? null : privacy.get(i).getValue()
-            );
-        }
+		Map<String, String> map = new HashMap<>();
+		for (int i = 0; i < privacy.size(); i++) {
+			map.put(
+				privacy.get(i).getType(),
+				privacy.get(i).getValue().equals("") ? null : privacy.get(i).getValue()
+			);
+		}
 
-        vo.setName(map.get("name"));
-        vo.setIhidnum(map.get("ihidnum"));
-        vo.setDlphotoimage(map.get("dlphotoimage"));
-        vo.setAddress(map.get("address"));
-        vo.setBirth(map.get("birth"));
-        vo.setExpatno(map.get("expatno"));
-        vo.setExpatnosn(map.get("expatnosn"));
-        vo.setRephonno(map.get("rephonno"));
-        vo.setTitle(map.get("title"));
-        vo.setUsrname(map.get("usrname"));
-        vo.setGivennames(map.get("givennames"));
-        vo.setPassporttype(map.get("passporttype"));
-        vo.setCountrycode(map.get("countrycode"));
-        vo.setPassportno(map.get("passportno"));
-        vo.setNationality(map.get("nationality"));
-        vo.setIssude(map.get("issude"));
-        vo.setExpirdate(map.get("expirdate"));
-        vo.setSex(map.get("sex"));
-        vo.setBearersigna(map.get("bearersigna"));
-        vo.setAuthority(map.get("authority"));
-        vo.setEmblnm(map.get("emblnm"));
-        vo.setCi(map.get("ci"));
+		vo.setName(map.get("name"));
+		vo.setIhidnum(map.get("ihidnum"));
+		vo.setDlphotoimage(map.get("dlphotoimage"));
+		vo.setAddress(map.get("address"));
+		vo.setBirth(map.get("birth"));
+		vo.setExpatno(map.get("expatno"));
+		vo.setExpatnosn(map.get("expatnosn"));
+		vo.setRephonno(map.get("rephonno"));
+		vo.setTitle(map.get("title"));
+		vo.setUsrname(map.get("usrname"));
+		vo.setGivennames(map.get("givennames"));
+		vo.setPassporttype(map.get("passporttype"));
+		vo.setCountrycode(map.get("countrycode"));
+		vo.setPassportno(map.get("passportno"));
+		vo.setNationality(map.get("nationality"));
+		vo.setIssude(map.get("issude"));
+		vo.setExpirdate(map.get("expirdate"));
+		vo.setSex(map.get("sex"));
+		vo.setBearersigna(map.get("bearersigna"));
+		vo.setAuthority(map.get("authority"));
+		vo.setEmblnm(map.get("emblnm"));
+		vo.setCi(map.get("ci"));
 
-        return vo;
-    }
+		return vo;
+	}
 
-    // Getter & Setter methods
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-
-    public String getIhidnum() { return ihidnum; }
-    public void setIhidnum(String ihidnum) { this.ihidnum = ihidnum; }
-
-    public String getDlphotoimage() { return dlphotoimage; }
-    public void setDlphotoimage(String dlphotoimage) { this.dlphotoimage = dlphotoimage; }
-
-    public String getAddress() { return address; }
-    public void setAddress(String address) { this.address = address; }
-
-    public String getBirth() { return birth; }
-    public void setBirth(String birth) { this.birth = birth; }
-
-    public String getExpatno() { return expatno; }
-    public void setExpatno(String expatno) { this.expatno = expatno; }
-
-    public String getExpatnosn() { return expatnosn; }
-    public void setExpatnosn(String expatnosn) { this.expatnosn = expatnosn; }
-
-    public String getRephonno() { return rephonno; }
-    public void setRephonno(String rephonno) { this.rephonno = rephonno; }
-
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
-
-    public String getUsrname() { return usrname; }
-    public void setUsrname(String usrname) { this.usrname = usrname; }
-
-    public String getGivennames() { return givennames; }
-    public void setGivennames(String givennames) { this.givennames = givennames; }
-
-    public String getPassporttype() { return passporttype; }
-    public void setPassporttype(String passporttype) { this.passporttype = passporttype; }
-
-    public String getCountrycode() { return countrycode; }
-    public void setCountrycode(String countrycode) { this.countrycode = countrycode; }
-
-    public String getPassportno() { return passportno; }
-    public void setPassportno(String passportno) { this.passportno = passportno; }
-
-    public String getNationality() { return nationality; }
-    public void setNationality(String nationality) { this.nationality = nationality; }
-
-    public String getIssude() { return issude; }
-    public void setIssude(String issude) { this.issude = issude; }
-
-    public String getExpirdate() { return expirdate; }
-    public void setExpirdate(String expirdate) { this.expirdate = expirdate; }
-
-    public String getSex() { return sex; }
-    public void setSex(String sex) { this.sex = sex; }
-
-    public String getBearersigna() { return bearersigna; }
-    public void setBearersigna(String bearersigna) { this.bearersigna = bearersigna; }
-
-    public String getAuthority() { return authority; }
-    public void setAuthority(String authority) { this.authority = authority; }
-
-    public String getEmblnm() { return emblnm; }
-    public void setEmblnm(String emblnm) { this.emblnm = emblnm; }
-
-    public String getCi() { return ci; }
-    public void setCi(String ci) { this.ci = ci; }
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/LicenseHonorVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/LicenseHonorVO.java
@@ -1,6 +1,9 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import com.raonsecure.omnione.core.data.iw.Unprotected;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 import java.io.Serializable;
 import java.util.HashMap;
@@ -21,135 +24,75 @@ import java.util.Map;
  *
  * </pre>
  */
+@Getter
+@Setter
+@NoArgsConstructor
 public class LicenseHonorVO implements Serializable {
-	
+
 	private static final long serialVersionUID = 1L;
 
-    private String name;              // 이름
-    private String ihidnum;           // 주민등록번호
-    private String address;           // 주소
-    private String birth;             // 생년월일
-    private String dlphotoimage;      // 사진이미지
-    
-    private String title;             // 신분증명
-    private String reptitle;          // 대표 타이틀
-    private String rephonno;          // 대표 보훈번호
-    private String reptarget;         // 대표 보훈대상
-    private String qualiflist;        // 경합 보훈대상 목록
-    private String nolist;            // 보훈번호 및 보훈대상 목록
-    private String issude;            // 발행일
-    private String qualifnm;          // 보훈대상명
-    private String honoreeno;         // 보훈번호
-    private String target;            // 대상
-    private String honrelation;       // 유공자와의 관계
-    private String registde;          // 등록일
-    private String disabledgrd;       // 상이 및 장애 등급
-    private String regno;             // 등록번호
-    private String ci;				  // 연계 정보
+	private String name;              // 이름
+	private String ihidnum;           // 주민등록번호
+	private String address;           // 주소
+	private String birth;             // 생년월일
+	private String dlphotoimage;      // 사진이미지
 
-    public LicenseHonorVO() {
-    }
+	private String title;             // 신분증명
+	private String reptitle;          // 대표 타이틀
+	private String rephonno;          // 대표 보훈번호
+	private String reptarget;         // 대표 보훈대상
+	private String qualiflist;        // 경합 보훈대상 목록
+	private String nolist;            // 보훈번호 및 보훈대상 목록
+	private String issude;            // 발행일
+	private String qualifnm;          // 보훈대상명
+	private String honoreeno;         // 보훈번호
+	private String target;            // 대상
+	private String honrelation;       // 유공자와의 관계
+	private String registde;          // 등록일
+	private String disabledgrd;       // 상이 및 장애 등급
+	private String regno;             // 등록번호
+	private String ci;                // 연계 정보
 
-    /**
+	/**
 	 * Privacy 목록과 License VO를 매핑
-	 * 
+	 *
 	 * @MethodName mapFromList
 	 * @param privacy Privacy목록
 	 * @return LicenseHonorVO
 	 */
-    public LicenseHonorVO mapFromList(List<Unprotected> privacy) {
-        LicenseHonorVO vo = new LicenseHonorVO();
+	public LicenseHonorVO mapFromList(List<Unprotected> privacy) {
+		LicenseHonorVO vo = new LicenseHonorVO();
 
-        Map<String, String> map = new HashMap<>();
-        for (int i = 0; i < privacy.size(); i++) {
-            map.put(
-        		privacy.get(i).getType(),
-        		privacy.get(i).getValue().equals("") ? null : privacy.get(i).getValue()
-            );
-        }
+		Map<String, String> map = new HashMap<>();
+		for (int i = 0; i < privacy.size(); i++) {
+			map.put(
+				privacy.get(i).getType(),
+				privacy.get(i).getValue().equals("") ? null : privacy.get(i).getValue()
+			);
+		}
 
-        vo.setName(map.get("name"));
-        vo.setIhidnum(map.get("ihidnum"));
-        vo.setDlphotoimage(map.get("dlphotoimage"));
-        vo.setAddress(map.get("address"));
-        vo.setBirth(map.get("birth"));
-        vo.setTitle(map.get("title"));
-        vo.setReptitle(map.get("reptitle"));
-        vo.setRephonno(map.get("rephonno"));
-        vo.setReptarget(map.get("reptarget"));
-        vo.setQualiflist(map.get("qualiflist"));
-        vo.setNolist(map.get("nolist"));
-        vo.setIssude(map.get("issude"));
-        vo.setQualifnm(map.get("qualifnm"));
-        vo.setHonoreeno(map.get("honoreeno"));
-        vo.setTarget(map.get("target"));
-        vo.setHonrelation(map.get("honrelation"));
-        vo.setRegistde(map.get("registde"));
-        vo.setDisabledgrd(map.get("disabledgrd"));
-        vo.setRegno(map.get("regno"));
+		vo.setName(map.get("name"));
+		vo.setIhidnum(map.get("ihidnum"));
+		vo.setDlphotoimage(map.get("dlphotoimage"));
+		vo.setAddress(map.get("address"));
+		vo.setBirth(map.get("birth"));
+		vo.setTitle(map.get("title"));
+		vo.setReptitle(map.get("reptitle"));
+		vo.setRephonno(map.get("rephonno"));
+		vo.setReptarget(map.get("reptarget"));
+		vo.setQualiflist(map.get("qualiflist"));
+		vo.setNolist(map.get("nolist"));
+		vo.setIssude(map.get("issude"));
+		vo.setQualifnm(map.get("qualifnm"));
+		vo.setHonoreeno(map.get("honoreeno"));
+		vo.setTarget(map.get("target"));
+		vo.setHonrelation(map.get("honrelation"));
+		vo.setRegistde(map.get("registde"));
+		vo.setDisabledgrd(map.get("disabledgrd"));
+		vo.setRegno(map.get("regno"));
 		vo.setCi(map.get("ci"));
 
-        return vo;
-    }
+		return vo;
+	}
 
-    // Getter & Setter methods
-    public String getName() { return name; }
-    public void setName(String name) { this.name = name; }
-
-    public String getIhidnum() { return ihidnum; }
-    public void setIhidnum(String ihidnum) { this.ihidnum = ihidnum; }
-
-    public String getDlphotoimage() { return dlphotoimage; }
-    public void setDlphotoimage(String dlphotoimage) { this.dlphotoimage = dlphotoimage; }
-
-    public String getAddress() { return address; }
-    public void setAddress(String address) { this.address = address; }
-
-    public String getBirth() { return birth; }
-    public void setBirth(String birth) { this.birth = birth; }
-
-    public String getTitle() { return title; }
-    public void setTitle(String title) { this.title = title; }
-
-    public String getReptitle() { return reptitle; }
-    public void setReptitle(String reptitle) { this.reptitle = reptitle; }
-
-    public String getRephonno() { return rephonno; }
-    public void setRephonno(String rephonno) { this.rephonno = rephonno; }
-
-    public String getReptarget() { return reptarget; }
-    public void setReptarget(String reptarget) { this.reptarget = reptarget; }
-
-    public String getQualiflist() { return qualiflist; }
-    public void setQualiflist(String qualiflist) { this.qualiflist = qualiflist; }
-
-    public String getNolist() { return nolist; }
-    public void setNolist(String nolist) { this.nolist = nolist; }
-
-    public String getIssude() { return issude; }
-    public void setIssude(String issude) { this.issude = issude; }
-
-    public String getQualifnm() { return qualifnm; }
-    public void setQualifnm(String qualifnm) { this.qualifnm = qualifnm; }
-
-    public String getHonoreeno() { return honoreeno; }
-    public void setHonoreeno(String honoreeno) { this.honoreeno = honoreeno; }
-
-    public String getTarget() { return target; }
-    public void setTarget(String target) { this.target = target; }
-
-    public String getHonrelation() { return honrelation; }
-    public void setHonrelation(String honrelation) { this.honrelation = honrelation; }
-
-    public String getRegistde() { return registde; }
-    public void setRegistde(String registde) { this.registde = registde; }
-
-    public String getDisabledgrd() { return disabledgrd; }
-    public void setDisabledgrd(String disabledgrd) { this.disabledgrd = disabledgrd; }
-
-    public String getRegno() { return regno; }
-    public void setRegno(String regno) { this.regno = regno; }
-    
-    public String getCi() { return ci; }
-    public void setCi(String ci) { this.ci = ci; }
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M120VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M120VO.java
@@ -1,6 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import egovframework.com.mip.mva.sp.config.ConfigBean;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -11,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description QR-CPM용 전처리 요청 메시지 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -19,6 +21,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class M120VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -35,53 +39,5 @@ public class M120VO implements Serializable {
 	private String mode;
 	/** 호스트 */
 	private String host;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public String getMode() {
-		return mode;
-	}
-
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	public String getHost() {
-		return host;
-	}
-
-	public void setHost(String host) {
-		this.host = host;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M200VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M200VO.java
@@ -1,6 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import egovframework.com.mip.mva.sp.config.ConfigBean;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -11,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description VP 요청 메시지 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -19,6 +21,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class M200VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -43,85 +47,5 @@ public class M200VO implements Serializable {
 	private Boolean telno;
 	/** 호스트명 */
 	private String host;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public String getMode() {
-		return mode;
-	}
-
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	public String getProfile() {
-		return profile;
-	}
-
-	public void setProfile(String profile) {
-		this.profile = profile;
-	}
-
-	public String getImage() {
-		return image;
-	}
-
-	public void setImage(String image) {
-		this.image = image;
-	}
-
-	public Boolean isCi() {
-		return ci;
-	}
-
-	public void setCi(Boolean ci) {
-		this.ci = ci;
-	}
-
-	public Boolean getTelno() {
-		return telno;
-	}
-
-	public void setTelno(Boolean telno) {
-		this.telno = telno;
-	}
-
-	public String getHost() {
-		return host;
-	}
-
-	public void setHost(String host) {
-		this.host = host;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M310VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M310VO.java
@@ -1,6 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import egovframework.com.mip.mva.sp.config.ConfigBean;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -11,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description Profile 요청 메시지 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -19,6 +21,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class M310VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -35,53 +39,5 @@ public class M310VO implements Serializable {
 	private String trxcode;
 	/** Base64로 인코딩된 Profile */
 	private String profile;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getRequest() {
-		return request;
-	}
-
-	public void setRequest(String request) {
-		this.request = request;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public String getProfile() {
-		return profile;
-	}
-
-	public void setProfile(String profile) {
-		this.profile = profile;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M320VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M320VO.java
@@ -1,6 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import egovframework.com.mip.mva.sp.config.ConfigBean;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -11,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description Image 요청 메시지 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -19,6 +21,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class M320VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -33,45 +37,5 @@ public class M320VO implements Serializable {
 	private String request;
 	/** 거래코드 */
 	private String trxcode;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getRequest() {
-		return request;
-	}
-
-	public void setRequest(String request) {
-		this.request = request;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M400VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M400VO.java
@@ -1,6 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import egovframework.com.mip.mva.sp.config.ConfigBean;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -11,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description VP 제출 메시지 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -19,6 +21,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class M400VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -34,54 +38,6 @@ public class M400VO implements Serializable {
 	/** 거래코드 */
 	private String trxcode;
 	/** 검증요청정보 */
-	private egovframework.com.mip.mva.sp.comm.vo.VP vp;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getRequest() {
-		return request;
-	}
-
-	public void setRequest(String request) {
-		this.request = request;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public egovframework.com.mip.mva.sp.comm.vo.VP getVp() {
-		return vp;
-	}
-
-	public void setVp(egovframework.com.mip.mva.sp.comm.vo.VP vp) {
-		this.vp = vp;
-	}
+	private VP vp;
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M900VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/M900VO.java
@@ -1,6 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
 import egovframework.com.mip.mva.sp.config.ConfigBean;
+import lombok.Getter;
+import lombok.Setter;
 
 import java.io.Serializable;
 
@@ -11,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 오류 메시지 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -19,6 +21,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class M900VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -35,53 +39,5 @@ public class M900VO implements Serializable {
 	private Integer errcode;
 	/** 오류메세지 */
 	private String errmsg;
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getVersion() {
-		return version;
-	}
-
-	public void setVersion(String version) {
-		this.version = version;
-	}
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public Integer getErrcode() {
-		return errcode;
-	}
-
-	public void setErrcode(Integer errcode) {
-		this.errcode = errcode;
-	}
-
-	public String getErrmsg() {
-		return errmsg;
-	}
-
-	public void setErrmsg(String errmsg) {
-		this.errmsg = errmsg;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/MipApiDataVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/MipApiDataVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +12,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 검증 API 데이터 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -17,6 +20,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class MipApiDataVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -25,21 +30,5 @@ public class MipApiDataVO implements Serializable {
 	private Boolean result;
 	/** 데이터 */
 	private String data;
-
-	public Boolean getResult() {
-		return result;
-	}
-
-	public void setResult(Boolean result) {
-		this.result = result;
-	}
-
-	public String getData() {
-		return data;
-	}
-
-	public void setData(String data) {
-		this.data = data;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/PushInfoVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/PushInfoVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * @Project 모바일 운전면허증 서비스 구축 사업
  * @PackageName mip.mva.sp.comm.vo
@@ -7,7 +10,7 @@ package egovframework.com.mip.mva.sp.comm.vo;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 푸시 요청 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -15,6 +18,8 @@ package egovframework.com.mip.mva.sp.comm.vo;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class PushInfoVO {
 
 	/** MS-CODE(조폐공사에 등록하여 할당 받음) */
@@ -38,85 +43,5 @@ public class PushInfoVO {
 	private Integer errcode;
 	/** 오류메세지 */
 	private String errmsg;
-
-	public String getMscode() {
-		return mscode;
-	}
-
-	public void setMscode(String mscode) {
-		this.mscode = mscode;
-	}
-
-	public String getPushType() {
-		return pushType;
-	}
-
-	public void setPushType(String pushType) {
-		this.pushType = pushType;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getTelno() {
-		return telno;
-	}
-
-	public void setTelno(String telno) {
-		this.telno = telno;
-	}
-
-	public String getData() {
-		return data;
-	}
-
-	public void setData(String data) {
-		this.data = data;
-	}
-
-	public Integer getKey() {
-		return key;
-	}
-
-	public void setKey(Integer key) {
-		this.key = key;
-	}
-
-	public Boolean getResult() {
-		return result;
-	}
-
-	public void setResult(Boolean result) {
-		this.result = result;
-	}
-
-	public String getResultMsg() {
-		return resultMsg;
-	}
-
-	public void setResultMsg(String resultMsg) {
-		this.resultMsg = resultMsg;
-	}
-
-	public Integer getErrcode() {
-		return errcode;
-	}
-
-	public void setErrcode(Integer errcode) {
-		this.errcode = errcode;
-	}
-
-	public String getErrmsg() {
-		return errmsg;
-	}
-
-	public void setErrmsg(String errmsg) {
-		this.errmsg = errmsg;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T510VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T510VO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +12,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description QR-MPM 시작용 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -17,6 +20,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class T510VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -32,45 +37,5 @@ public class T510VO implements Serializable {
 
 	/** Base64로 인코딩된 M200 메세지 */
 	private String m200Base64;
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getMode() {
-		return mode;
-	}
-
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public String getAppCode() {
-		return appCode;
-	}
-
-	public void setAppCode(String appCode) {
-		this.appCode = appCode;
-	}
-
-	public String getM200Base64() {
-		return m200Base64;
-	}
-
-	public void setM200Base64(String m200Base64) {
-		this.m200Base64 = m200Base64;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T520VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T520VO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +12,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description QR-CPM 시작용 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -17,6 +20,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class T520VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -28,29 +33,5 @@ public class T520VO implements Serializable {
 
 	/** Base64로 인코딩된 M120 메세지 */
 	private String m120Base64;
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public String getM120Base64() {
-		return m120Base64;
-	}
-
-	public void setM120Base64(String m120Base64) {
-		this.m120Base64 = m120Base64;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T530VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T530VO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +12,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description App to App 시작용 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -17,6 +20,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class T530VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -32,45 +37,5 @@ public class T530VO implements Serializable {
 
 	/** Base64로 인코딩된 M200 메세지 */
 	private String m200Base64;
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getMode() {
-		return mode;
-	}
-
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public String getAppCode() {
-		return appCode;
-	}
-
-	public void setAppCode(String appCode) {
-		this.appCode = appCode;
-	}
-
-	public String getM200Base64() {
-		return m200Base64;
-	}
-
-	public void setM200Base64(String m200Base64) {
-		this.m200Base64 = m200Base64;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T540VO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/T540VO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +12,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 푸시 시작용 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -17,6 +20,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class T540VO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -36,61 +41,5 @@ public class T540VO implements Serializable {
 
 	/** Base64로 인코딩된 M200 메세지 */
 	private String m200Base64;
-
-	public String getCmd() {
-		return cmd;
-	}
-
-	public void setCmd(String cmd) {
-		this.cmd = cmd;
-	}
-
-	public String getMode() {
-		return mode;
-	}
-
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public String getAppCode() {
-		return appCode;
-	}
-
-	public void setAppCode(String appCode) {
-		this.appCode = appCode;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getTelno() {
-		return telno;
-	}
-
-	public void setTelno(String telno) {
-		this.telno = telno;
-	}
-
-	public String getM200Base64() {
-		return m200Base64;
-	}
-
-	public void setM200Base64(String m200Base64) {
-		this.m200Base64 = m200Base64;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/TrxInfoVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/TrxInfoVO.java
@@ -1,5 +1,9 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+import lombok.ToString;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +13,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 거래정보 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -18,6 +22,9 @@ import java.io.Serializable;
  * 2025.02. 13.    박성완           표준프레임워크 v4.3 - toString 메서드 추가
  * </pre>
  */
+@Getter
+@Setter
+@ToString
 public class TrxInfoVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -50,139 +57,5 @@ public class TrxInfoVO implements Serializable {
 	private String regDt;
 	/** 수정일시 */
 	private String udtDt;
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public String getMode() {
-		return mode;
-	}
-
-	public void setMode(String mode) {
-		this.mode = mode;
-	}
-
-	public String getNonce() {
-		return nonce;
-	}
-
-	public void setNonce(String nonce) {
-		this.nonce = nonce;
-	}
-
-	public String getZkpNonce() {
-		return zkpNonce;
-	}
-
-	public void setZkpNonce(String zkpNonce) {
-		this.zkpNonce = zkpNonce;
-	}
-
-	public String getVpVerifyResult() {
-		return vpVerifyResult;
-	}
-
-	public void setVpVerifyResult(String vpVerifyResult) {
-		this.vpVerifyResult = vpVerifyResult;
-	}
-
-	public String getVp() {
-		return vp;
-	}
-
-	public void setVp(String vp) {
-		this.vp = vp;
-	}
-
-	public String getTrxStsCode() {
-		return trxStsCode;
-	}
-
-	public void setTrxStsCode(String trxStsCode) {
-		this.trxStsCode = trxStsCode;
-	}
-
-	public String getProfileSendDt() {
-		return profileSendDt;
-	}
-
-	public void setProfileSendDt(String profileSendDt) {
-		this.profileSendDt = profileSendDt;
-	}
-
-	public String getImgSendDt() {
-		return imgSendDt;
-	}
-
-	public void setImgSendDt(String imgSendDt) {
-		this.imgSendDt = imgSendDt;
-	}
-
-	public String getVpReceptDt() {
-		return vpReceptDt;
-	}
-
-	public void setVpReceptDt(String vpReceptDt) {
-		this.vpReceptDt = vpReceptDt;
-	}
-
-	public String getErrorCn() {
-		return errorCn;
-	}
-
-	public void setErrorCn(String errorCn) {
-		this.errorCn = errorCn;
-	}
-
-	public String getRegDt() {
-		return regDt;
-	}
-
-	public void setRegDt(String regDt) {
-		this.regDt = regDt;
-	}
-
-	public String getUdtDt() {
-		return udtDt;
-	}
-
-	public void setUdtDt(String udtDt) {
-		this.udtDt = udtDt;
-	}
-	
-	// toString 메서드 추가(2025.02.13 박성완)
-	@Override
-	public String toString() {
-	    return "TrxInfo{ " +
-	            "trxcode = " + trxcode + " | " +
-	            "svcCode = " + svcCode + " | " +
-	            "mode = " + mode + " | " +
-	            "nonce = " + nonce + " | " +
-	            "zkpNonce = " + zkpNonce + " | " +
-	            "vpVerifyResult = " + vpVerifyResult + " | " +
-	            "vp = " + vp + " | " +
-	            "trxStsCode = " + trxStsCode + " | " +
-	            "profileSendDt = " + profileSendDt + " | " +
-	            "imgSendDt = " + imgSendDt + " | " +
-	            "vpReceptDt = " + vpReceptDt + " | " +
-	            "errorCn = " + errorCn + " | " +
-	            "regDt = " + regDt + " | " +
-	            "udtDt = " + udtDt +
-	            "}";
-	}
-
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/VP.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/VP.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 import java.util.List;
 
@@ -10,7 +13,7 @@ import java.util.List;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description VP 정보 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -18,6 +21,8 @@ import java.util.List;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class VP implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -40,77 +45,5 @@ public class VP implements Serializable {
 	private String type;
 	/** 암호화된 검증 요청 데이터 */
 	private String data;
-
-	public Integer getEncryptType() {
-		return encryptType;
-	}
-
-	public void setEncryptType(Integer encryptType) {
-		this.encryptType = encryptType;
-	}
-
-	public Integer getKeyType() {
-		return keyType;
-	}
-
-	public void setKeyType(Integer keyType) {
-		this.keyType = keyType;
-	}
-
-	public String getDid() {
-		return did;
-	}
-
-	public void setDid(String did) {
-		this.did = did;
-	}
-
-	public String getNonce() {
-		return nonce;
-	}
-
-	public void setNonce(String nonce) {
-		this.nonce = nonce;
-	}
-
-	public String getZkpNonce() {
-		return zkpNonce;
-	}
-
-	public void setZkpNonce(String zkpNonce) {
-		this.zkpNonce = zkpNonce;
-	}
-
-	public String getType() {
-		return type;
-	}
-
-	public void setType(String type) {
-		this.type = type;
-	}
-
-	public String getData() {
-		return data;
-	}
-
-	public void setData(String data) {
-		this.data = data;
-	}
-
-	public Integer getPresentType() {
-		return presentType;
-	}
-
-	public void setPresentType(Integer presentType) {
-		this.presentType = presentType;
-	}
-
-	public List<String> getAuthType() {
-		return authType;
-	}
-
-	public void setAuthType(List<String> authType) {
-		this.authType = authType;
-	}
 
 }

--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/WsInfoVO.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/vo/WsInfoVO.java
@@ -1,5 +1,8 @@
 package egovframework.com.mip.mva.sp.comm.vo;
 
+import lombok.Getter;
+import lombok.Setter;
+
 import java.io.Serializable;
 
 /**
@@ -9,7 +12,7 @@ import java.io.Serializable;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description 웹소켓 정보 VO
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
@@ -17,6 +20,8 @@ import java.io.Serializable;
  * 2024. 5. 28.    민기주           최초생성
  * </pre>
  */
+@Getter
+@Setter
 public class WsInfoVO implements Serializable {
 
 	private static final long serialVersionUID = 1L;
@@ -33,53 +38,5 @@ public class WsInfoVO implements Serializable {
 	private String result;
 	/** 상태 */
 	private String status;
-
-	public String getConnUrl() {
-		return connUrl;
-	}
-
-	public void setConnUrl(String connUrl) {
-		this.connUrl = connUrl;
-	}
-
-	public Integer getTimeout() {
-		return timeout;
-	}
-
-	public void setTimeout(Integer timeout) {
-		this.timeout = timeout;
-	}
-
-	public String getTrxcode() {
-		return trxcode;
-	}
-
-	public void setTrxcode(String trxcode) {
-		this.trxcode = trxcode;
-	}
-
-	public String getSvcCode() {
-		return svcCode;
-	}
-
-	public void setSvcCode(String svcCode) {
-		this.svcCode = svcCode;
-	}
-
-	public String getResult() {
-		return result;
-	}
-
-	public void setResult(String result) {
-		this.result = result;
-	}
-
-	public String getStatus() {
-		return status;
-	}
-
-	public void setStatus(String status) {
-		this.status = status;
-	}
 
 }


### PR DESCRIPTION
EgovMobileId 모듈의 comm/vo 패키지에 포함된 18개 VO 클래스에 Lombok 어노테이션을 적용합니다.

## 변경 내용

수작업으로 작성된 getter/setter 메서드를 Lombok 어노테이션으로 교체하여 보일러플레이트 코드를 제거했습니다.

| 클래스 | 적용 어노테이션 |
|---|---|
| M120VO, M200VO, M310VO, M320VO, M400VO, M900VO | @Getter @Setter |
| MipApiDataVO, PushInfoVO, T510VO, T520VO, T530VO, T540VO, WsInfoVO, VP | @Getter @Setter |
| TrxInfoVO | @Getter @Setter @ToString (수동 toString() 대체) |
| LicenseDriverVO, LicenseExpatVO, LicenseHonorVO | @Getter @Setter @NoArgsConstructor |

## 관련 PR

- 선행 PR: #20 (config/vo 패키지 Lombok 적용)

## 체크리스트

- [x] 단일 주제만 다룸 (다른 변경 없음)
- [x] 기존 동작에 영향 없음 (getter/setter 시그니처 동일하게 유지)
- [x] 의존성 변경 없음 (lombok이 이미 EgovMobileId/pom.xml에 선언됨)