### PR TITLE
[test][EgovLoginPolicy] EgovLoginPolicyUtility·EgovHtmlTagFilterWrapper 단위 테스트 추가

### DIFF
--- a/EgovLoginPolicy/src/test/java/egovframework/com/filter/EgovHtmlTagFilterWrapperTest.java
+++ b/EgovLoginPolicy/src/test/java/egovframework/com/filter/EgovHtmlTagFilterWrapperTest.java
@@ -1,0 +1,136 @@
+package egovframework.com.filter;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovHtmlTagFilterWrapper 단위 테스트.
+ * Spring 컨텍스트 없이 XSS 방어용 HTML 이스케이프 로직을 검증한다.
+ */
+class EgovHtmlTagFilterWrapperTest {
+
+    private MockHttpServletRequest mockRequest;
+
+    @BeforeEach
+    void setUp() {
+        mockRequest = new MockHttpServletRequest();
+    }
+
+    // ---------------------------------------------------------------
+    // getParameter
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("getParameter: HTML 특수문자가 이스케이프된다")
+    void getParameter_htmlSpecialChars_escaped() {
+        mockRequest.setParameter("input", "<script>alert('xss')</script>");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        String result = wrapper.getParameter("input");
+
+        // escapeHtml4는 홑따옴표(')를 이스케이프하지 않으므로 그대로 유지된다
+        assertThat(result).isEqualTo("&lt;script&gt;alert('xss')&lt;/script&gt;");
+    }
+
+    @Test
+    @DisplayName("getParameter: 일반 문자열은 변경 없이 반환된다")
+    void getParameter_plainText_unchanged() {
+        mockRequest.setParameter("name", "홍길동");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        assertThat(wrapper.getParameter("name")).isEqualTo("홍길동");
+    }
+
+    @Test
+    @DisplayName("getParameter: 존재하지 않는 파라미터는 null을 반환한다")
+    void getParameter_missingParam_returnsNull() {
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        assertThat(wrapper.getParameter("notExist")).isNull();
+    }
+
+    @Test
+    @DisplayName("getParameter: & 문자는 &amp;로 이스케이프된다")
+    void getParameter_ampersand_escaped() {
+        mockRequest.setParameter("q", "A & B");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        assertThat(wrapper.getParameter("q")).isEqualTo("A &amp; B");
+    }
+
+    @Test
+    @DisplayName("getParameter: 쌍따옴표가 &quot;로 이스케이프된다")
+    void getParameter_doubleQuote_escaped() {
+        mockRequest.setParameter("attr", "value\"injected");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        assertThat(wrapper.getParameter("attr")).isEqualTo("value&quot;injected");
+    }
+
+    @Test
+    @DisplayName("getParameter: 홑따옴표는 escapeHtml4 규격상 이스케이프되지 않는다")
+    void getParameter_singleQuote_notEscaped() {
+        mockRequest.setParameter("attr", "it's fine");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        assertThat(wrapper.getParameter("attr")).isEqualTo("it's fine");
+    }
+
+    // ---------------------------------------------------------------
+    // getParameterValues
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("getParameterValues: 배열 내 모든 값이 이스케이프된다")
+    void getParameterValues_multipleValues_allEscaped() {
+        mockRequest.addParameter("tags", "<b>bold</b>");
+        mockRequest.addParameter("tags", "<i>italic</i>");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        String[] values = wrapper.getParameterValues("tags");
+
+        assertThat(values).containsExactly(
+                "&lt;b&gt;bold&lt;/b&gt;",
+                "&lt;i&gt;italic&lt;/i&gt;"
+        );
+    }
+
+    @Test
+    @DisplayName("getParameterValues: 존재하지 않는 파라미터는 빈 배열을 반환한다")
+    void getParameterValues_missingParam_returnsEmptyArray() {
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        String[] values = wrapper.getParameterValues("notExist");
+
+        assertThat(values).isNotNull().isEmpty();
+    }
+
+    // ---------------------------------------------------------------
+    // getParameterMap
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("getParameterMap: 맵 내 모든 파라미터 값이 이스케이프된다")
+    void getParameterMap_allValuesEscaped() {
+        mockRequest.setParameter("title", "<h1>제목</h1>");
+        mockRequest.setParameter("normal", "일반값");
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        var paramMap = wrapper.getParameterMap();
+
+        assertThat(paramMap.get("title")).containsExactly("&lt;h1&gt;제목&lt;/h1&gt;");
+        assertThat(paramMap.get("normal")).containsExactly("일반값");
+    }
+
+    @Test
+    @DisplayName("getParameterMap: 빈 요청이면 빈 맵을 반환한다")
+    void getParameterMap_emptyRequest_returnsEmptyMap() {
+        EgovHtmlTagFilterWrapper wrapper = new EgovHtmlTagFilterWrapper(mockRequest);
+
+        assertThat(wrapper.getParameterMap()).isEmpty();
+    }
+}

--- a/EgovLoginPolicy/src/test/java/egovframework/com/uat/uap/util/EgovLoginPolicyUtilityTest.java
+++ b/EgovLoginPolicy/src/test/java/egovframework/com/uat/uap/util/EgovLoginPolicyUtilityTest.java
@@ -1,0 +1,146 @@
+package egovframework.com.uat.uap.util;
+
+import egovframework.com.uat.uap.entity.LoginPolicy;
+import egovframework.com.uat.uap.service.LoginPolicyVO;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * EgovLoginPolicyUtility 단위 테스트.
+ * Spring 컨텍스트 없이 entity-VO 양방향 변환 로직을 검증한다.
+ */
+class EgovLoginPolicyUtilityTest {
+
+    // ---------------------------------------------------------------
+    // entityToVO
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("entityToVO: 모든 필드가 VO로 복사된다")
+    void entityToVO_allFields_copiedCorrectly() {
+        LocalDateTime now = LocalDateTime.of(2024, 1, 15, 9, 30, 0);
+
+        LoginPolicy entity = new LoginPolicy();
+        entity.setEmployerId("user001");
+        entity.setIpInfo("192.168.1.100");
+        entity.setDplctPermAt("N");
+        entity.setLmttAt("Y");
+        entity.setFrstRegisterId("admin");
+        entity.setFrstRegisterPnttm(now);
+        entity.setLastUpdusrId("admin");
+        entity.setLastUpdtPnttm(now);
+
+        LoginPolicyVO vo = EgovLoginPolicyUtility.entityToVO(entity);
+
+        assertThat(vo.getEmployerId()).isEqualTo("user001");
+        assertThat(vo.getIpInfo()).isEqualTo("192.168.1.100");
+        assertThat(vo.getDplctPermAt()).isEqualTo("N");
+        assertThat(vo.getLmttAt()).isEqualTo("Y");
+        assertThat(vo.getFrstRegisterId()).isEqualTo("admin");
+        assertThat(vo.getFrstRegisterPnttm()).isEqualTo(now);
+        assertThat(vo.getLastUpdusrId()).isEqualTo("admin");
+        assertThat(vo.getLastUpdtPnttm()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("entityToVO: null 필드는 VO에도 null로 매핑된다")
+    void entityToVO_nullFields_remainNull() {
+        LoginPolicy entity = new LoginPolicy();
+        entity.setEmployerId("user002");
+        // 나머지 필드 null
+
+        LoginPolicyVO vo = EgovLoginPolicyUtility.entityToVO(entity);
+
+        assertThat(vo.getEmployerId()).isEqualTo("user002");
+        assertThat(vo.getIpInfo()).isNull();
+        assertThat(vo.getDplctPermAt()).isNull();
+        assertThat(vo.getLmttAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("entityToVO: 반환 객체는 항상 새 인스턴스다")
+    void entityToVO_returnsNewInstance() {
+        LoginPolicy entity = new LoginPolicy();
+        entity.setEmployerId("user003");
+
+        LoginPolicyVO vo1 = EgovLoginPolicyUtility.entityToVO(entity);
+        LoginPolicyVO vo2 = EgovLoginPolicyUtility.entityToVO(entity);
+
+        assertThat(vo1).isNotSameAs(vo2);
+    }
+
+    // ---------------------------------------------------------------
+    // vOToEntity
+    // ---------------------------------------------------------------
+
+    @Test
+    @DisplayName("vOToEntity: 모든 필드가 entity로 복사된다")
+    void vOToEntity_allFields_copiedCorrectly() {
+        LocalDateTime now = LocalDateTime.of(2024, 6, 1, 12, 0, 0);
+
+        LoginPolicyVO vo = new LoginPolicyVO();
+        vo.setEmployerId("user010");
+        vo.setIpInfo("10.0.0.1");
+        vo.setDplctPermAt("Y");
+        vo.setLmttAt("N");
+        vo.setFrstRegisterId("system");
+        vo.setFrstRegisterPnttm(now);
+        vo.setLastUpdusrId("system");
+        vo.setLastUpdtPnttm(now);
+
+        LoginPolicy entity = EgovLoginPolicyUtility.vOToEntity(vo);
+
+        assertThat(entity.getEmployerId()).isEqualTo("user010");
+        assertThat(entity.getIpInfo()).isEqualTo("10.0.0.1");
+        assertThat(entity.getDplctPermAt()).isEqualTo("Y");
+        assertThat(entity.getLmttAt()).isEqualTo("N");
+        assertThat(entity.getFrstRegisterId()).isEqualTo("system");
+        assertThat(entity.getFrstRegisterPnttm()).isEqualTo(now);
+        assertThat(entity.getLastUpdusrId()).isEqualTo("system");
+        assertThat(entity.getLastUpdtPnttm()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("vOToEntity: VO 전용 필드(userNm, regYn)는 entity에 복사되지 않는다")
+    void vOToEntity_voOnlyFields_notCopied() {
+        LoginPolicyVO vo = new LoginPolicyVO();
+        vo.setEmployerId("user011");
+        vo.setUserNm("홍길동");
+        vo.setRegYn("Y");
+
+        LoginPolicy entity = EgovLoginPolicyUtility.vOToEntity(vo);
+
+        // entity에는 userNm, regYn 필드가 없으므로 employerId만 확인
+        assertThat(entity.getEmployerId()).isEqualTo("user011");
+    }
+
+    @Test
+    @DisplayName("vOToEntity → entityToVO: 라운드트립 시 공통 필드 값이 보존된다")
+    void roundTrip_voToEntityToVO_preservesCommonFields() {
+        LocalDateTime ts = LocalDateTime.of(2024, 3, 20, 8, 0, 0);
+
+        LoginPolicyVO original = new LoginPolicyVO();
+        original.setEmployerId("user020");
+        original.setIpInfo("172.16.0.5");
+        original.setDplctPermAt("N");
+        original.setLmttAt("N");
+        original.setFrstRegisterId("admin");
+        original.setFrstRegisterPnttm(ts);
+        original.setLastUpdusrId("admin");
+        original.setLastUpdtPnttm(ts);
+
+        LoginPolicyVO restored = EgovLoginPolicyUtility.entityToVO(
+                EgovLoginPolicyUtility.vOToEntity(original));
+
+        assertThat(restored.getEmployerId()).isEqualTo(original.getEmployerId());
+        assertThat(restored.getIpInfo()).isEqualTo(original.getIpInfo());
+        assertThat(restored.getDplctPermAt()).isEqualTo(original.getDplctPermAt());
+        assertThat(restored.getLmttAt()).isEqualTo(original.getLmttAt());
+        assertThat(restored.getFrstRegisterId()).isEqualTo(original.getFrstRegisterId());
+        assertThat(restored.getFrstRegisterPnttm()).isEqualTo(original.getFrstRegisterPnttm());
+    }
+}


### PR DESCRIPTION
## 변경 사유

EgovLoginPolicy 모듈에 단위 테스트가 전혀 없어 유틸리티 로직의 회귀 방지가 불가능한 상태였다.
Spring 컨텍스트 없이 검증할 수 있는 순수 로직 클래스 2개를 선정하여 최초 단위 테스트를 도입한다.

## 변경 내용

### `EgovLoginPolicyUtilityTest` (6개 케이스)
- `entityToVO`: 전체 필드 복사, null 필드 유지, 매번 새 인스턴스 반환
- `vOToEntity`: 전체 필드 복사, VO 전용 필드(userNm·regYn) 미복사 확인
- 라운드트립(VO → entity → VO) 시 공통 필드 값 보존

### `EgovHtmlTagFilterWrapperTest` (10개 케이스)
- `getParameter`: XSS 문자열 이스케이프, 일반 텍스트 통과, 없는 파라미터 null, `&` / `"` 이스케이프, 홑따옴표 비이스케이프(escapeHtml4 규격)
- `getParameterValues`: 다중 값 전체 이스케이프, 없는 파라미터 빈 배열
- `getParameterMap`: 맵 전체 이스케이프, 빈 요청 빈 맵

## 테스트

```
mvn test -Dtest="EgovLoginPolicyUtilityTest,EgovHtmlTagFilterWrapperTest"
# Tests run: 16, Failures: 0, Errors: 0, Skipped: 0 — BUILD SUCCESS
```

## 체크리스트

- [x] 단일 주제만 다룸 (테스트 파일 2개 신규 추가만 포함, 빌드 설정 변경 없음)
- [x] 기존 동작에 영향 없음 (테스트 코드만 추가)
- [x] 테스트 통과 확인 (16/16 green)
