### PR TITLE
build(config-server): 관리 의존성 버전을 상위 BOM에서 상속

### DIFF
--- a/ConfigServer/pom.xml
+++ b/ConfigServer/pom.xml
@@ -4,7 +4,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>egovframework</groupId>
     <artifactId>ConfigServer</artifactId>
-    <version>5.0.0</version>
     <name>ConfigServer</name>
     <url>https://www.egovframe.go.kr</url>
 
@@ -24,13 +23,8 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
         <logback.version>1.5.32</logback.version>
-        <log4j2.version>2.25.3</log4j2.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <tomcat-embed.version>10.1.52</tomcat-embed.version>
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
+        <tomcat.version>10.1.52</tomcat.version>
         <commons-configuration2.version>2.11.0</commons-configuration2.version>
     </properties>
 
@@ -85,72 +79,59 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <!-- Logging -->
         <!-- CVE-2025-68161: 취약점 보완용 업데이트 -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <!-- CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-annotations-api</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <!-- CVE-2025-48734: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
         </dependency>
         <!-- CVE-2025-48924: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <!-- CVE-2025-46392: 보안취약점 보완용 직접 주입 -->
         <dependency>


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

ConfigServer에서 상위 POM 및 Spring Boot BOM이 관리하는 버전을 개별 의존성에 다시 선언하여 발생하는 Maven 및 언어 서버 경고를 해소합니다.

중복 선언을 제거하고 상위 POM/BOM의 의존성 관리 체계를 따르도록 POM을 정리했습니다.

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

### `ConfigServer/pom.xml`

- 부모 POM과 중복되는 프로젝트 버전 `5.0.0` 선언 제거
- 상위 POM이 동일하게 제공하는 속성 제거
  - `java.version`
  - `log4j2.version`
  - `slf4j.version`
  - `commons-beanutils.version`
  - `commons-lang3.version`
- 관리 대상 의존성 13개의 개별 `<version>` 선언 제거
  - Logback 2개
  - Log4j 2개
  - SLF4J 2개
  - Tomcat 5개
  - Commons BeanUtils
  - Commons Lang
- Tomcat 재정의 속성을 Spring Boot BOM의 공식 속성인 `tomcat.version`으로 변경
- 별도 보안 버전으로 지정한 다음 버전 유지
  - Logback `1.5.32`
  - Tomcat `10.1.52`
  - Commons Configuration `2.11.0`

유효 POM 확인 결과 기존 의존성 버전은 변경되지 않았습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

### 실행 환경

- Eclipse Temurin JDK `17.0.17+10`
- Apache Maven `3.9.9`

### 실행 명령

```shell
mvn -f ConfigServer/pom.xml test
```

### 실행 결과

```text
BUILD SUCCESS
```

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

해당 없음. 애플리케이션 UI 변경이 아닌 Maven POM 정리입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/aHLPMtq7hhQ
