### PR TITLE
fix(AuthorizeTokenService): 정지된 regDate + SimpleDateFormat 동시성 결함 수정

### DIFF
--- a/EgovLogin/src/main/java/egovframework/com/uat/uia/token/AuthorizeTokenService.java
+++ b/EgovLogin/src/main/java/egovframework/com/uat/uia/token/AuthorizeTokenService.java
@@ -7,15 +7,22 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 @Service
 @Slf4j
 public class AuthorizeTokenService {
 
-    private final Date date = new Date();
-    private final SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+    // 정확성/동시성: 기존에는 빈 생성 시점에 고정된 Date 필드와 스레드 비안전한
+    // SimpleDateFormat 인스턴스 필드를 @Service(싱글턴)에서 공유했다.
+    // - regDate 가 앱 기동 시각으로 고정되어 실제 발급 시각을 반영하지 못했고,
+    // - 동시 요청 시 SimpleDateFormat 공유로 출력 손상/예외가 발생할 수 있었다.
+    // 불변·스레드 안전한 DateTimeFormatter 로 대체하고 시각은 호출 시점에 계산한다.
+    private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+
     private final RedisTemplate<String, AuthorizeToken> authRedisTemplate;
     private final RedisTemplate<String, String> tokenRedisTemplate;
 
@@ -31,9 +38,13 @@ public class AuthorizeTokenService {
 
     @CachePut(value="authRedis", key="#username")
     public void saveToken(String username, String tokenKey, String refreshToken, String expDate) {
-        AuthorizeToken AuthorizeToken = new AuthorizeToken(
-                username, tokenKey, refreshToken, dateFormat.format(date), dateFormat.format(System.currentTimeMillis()+Long.parseLong(expDate)));
-        authRedisTemplate.opsForValue().set(username, AuthorizeToken);
+        long now = System.currentTimeMillis();
+        String regDate = LocalDateTime.now().format(DATE_FORMAT);
+        String expDateStr = LocalDateTime.ofInstant(
+                Instant.ofEpochMilli(now + Long.parseLong(expDate)), ZoneId.systemDefault()).format(DATE_FORMAT);
+        AuthorizeToken authorizeToken = new AuthorizeToken(
+                username, tokenKey, refreshToken, regDate, expDateStr);
+        authRedisTemplate.opsForValue().set(username, authorizeToken);
     }
 
     @CacheEvict(value="authRedis", key="#username")


### PR DESCRIPTION
## 요약
인증 토큰 발급 서비스 `AuthorizeTokenService`(`@Service` 싱글턴)의 시간 처리에 있는 **정확성 결함 1건 + 스레드 안전성 결함 1건**을 수정합니다.

## 문제 (재현)

### ① 정확성 — `regDate`가 앱 기동 시각으로 고정
```java
private final Date date = new Date();                 // 빈 생성 시 1회만
... new AuthorizeToken(..., dateFormat.format(date), ...) // regDate = 항상 기동 시각
```
`date`가 필드로 한 번만 초기화돼, 발급되는 모든 토큰의 `regDate`(발급일시)가 **서비스 시작 시각으로 고정**됩니다. 실제 발급 시각을 기록하지 못합니다.
- 재현: 1.2초 간격 두 번 발급 → `regDate` 동일. 수정 후 경과가 반영됩니다.

### ② 안정성 — 스레드 비안전 `SimpleDateFormat` 공유
`SimpleDateFormat`은 스레드 안전하지 않습니다(JDK 문서). `@Service` 싱글턴이 이를 인스턴스 필드로 공유해 `saveToken()`에서 `format()`을 호출하므로, **동시 로그인 시 출력 손상·예외**가 발생할 수 있습니다.
- 재현: 32스레드 × 20,000회 포맷을 단일 스레드 정답과 대조 → 기존 **약 116,000~140,000 / 640,000(18~22%) 손상·예외**(3회 재현). 수정본 **0**.

## 수정
`Date`·`SimpleDateFormat` 공유 필드를 제거하고, 불변·스레드 안전한 `DateTimeFormatter`(`static final`)로 대체합니다. 발급/만료 시각은 **호출 시점에 계산**합니다.
```java
private static final DateTimeFormatter DATE_FORMAT = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
...
String regDate = LocalDateTime.now().format(DATE_FORMAT);
String expDateStr = LocalDateTime.ofInstant(
        Instant.ofEpochMilli(now + Long.parseLong(expDate)), ZoneId.systemDefault()).format(DATE_FORMAT);
```

## 검증 (JDK 17)
- **동시성**: 위 재현 하네스에서 수정본 손상·예외 **0 / 640,000**(3회).
- **정확성**: `regDate`가 발급 시점을 반영(기동 시각 고정 해소).
- **포맷 동일성**: 랜덤 epoch 5,000개를 기존 `SimpleDateFormat` 출력과 대조 → **불일치 0**(`expDate` 출력·기본 타임존 동작 불변).
- **컴파일**: `javac` 통과.

## 영향 범위
- 공개 시그니처·출력 포맷 불변. 시간 계산 위치만 필드→호출 시점으로 이동. 순수 개선(+18 / −7).