### PR TITLE
fix(HttpUtil): RestTemplate connect/read 타임아웃 설정 (무응답 무한 블록 방지, CWE-400)

### DIFF
--- a/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/util/HttpUtil.java
+++ b/EgovMobileId/src/main/java/egovframework/com/mip/mva/sp/comm/util/HttpUtil.java
@@ -3,6 +3,7 @@ package egovframework.com.mip.mva.sp.comm.util;
 import egovframework.com.mip.mva.sp.comm.enums.MipErrorEnum;
 import egovframework.com.mip.mva.sp.comm.exception.SpException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 
@@ -13,19 +14,34 @@ import org.springframework.web.client.RestTemplate;
  * @Author Min Gi Ju
  * @Date 2022. 6. 3.
  * @Description Http Call Util
- * 
+ *
  * <pre>
  * ==================================================
  * DATE            AUTHOR           NOTE
  * ==================================================
  * 2024. 5. 28.    민기주           최초생성
+ * 2026. 7. 24.    EricSeokgon      RestTemplate connect/read 타임아웃 설정 (무응답 무한 블록 방지, CWE-400)
  * </pre>
  */
 public class HttpUtil {
 
+	// 안정성: 기본 RestTemplate 은 connect/read 타임아웃이 없어(무한 대기) 외부 서버가
+	// 무응답이면 호출 스레드가 영구히 블록될 수 있다(CWE-400 자원 고갈).
+	// 타임아웃을 설정한 요청 팩토리로 RestTemplate 을 구성해 재사용한다.
+	private static final int CONNECT_TIMEOUT_MS = 5000;
+	private static final int READ_TIMEOUT_MS = 30000;
+	private static final RestTemplate REST_TEMPLATE = createRestTemplate();
+
+	private static RestTemplate createRestTemplate() {
+		SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+		factory.setConnectTimeout(CONNECT_TIMEOUT_MS);
+		factory.setReadTimeout(READ_TIMEOUT_MS);
+		return new RestTemplate(factory);
+	}
+
 	/**
 	 * Http Call(POST) 실행
-	 * 
+	 *
 	 * @MethodName executeHttpPost
 	 * @param url URL
 	 * @param param 파라미터
@@ -33,11 +49,10 @@ public class HttpUtil {
 	 * @throws SpException
 	 */
 	public static String executeHttpPost(String url, Object param) throws SpException {
-		RestTemplate restTemplate = new RestTemplate();
 		ResponseEntity<String> response = null;
 
 		try {
-			response = restTemplate.postForEntity(url, param, String.class);
+			response = REST_TEMPLATE.postForEntity(url, param, String.class);
 		} catch (RestClientException e) {
 			throw new SpException(MipErrorEnum.SP_NETWORK_ERROR);
 		}


### PR DESCRIPTION
## 요약
인증/모바일 신분증 서비스의 HTTP 유틸 `HttpUtil`이 기본 `RestTemplate`(타임아웃 없음)으로 외부 서버를 호출합니다. 무응답 시 호출 스레드가 무한 대기하는 **CWE-400 자원 고갈** 위험을 수정합니다.

## 문제 (재현)
`executeHttpPost`가 `new RestTemplate()`(기본 `SimpleClientHttpRequestFactory` = connect/read 타임아웃 0=무한)로 외부 푸시 서버(`serverDomain`)에 `postForEntity`를 호출합니다. `PushServiceImpl`·`WebServiceImpl`에서 사용되며, 상대 서버가 응답하지 않으면 스레드가 영구 블록됩니다.
- 재현(소켓 레벨, 무응답 서버 모사): 타임아웃 미설정은 3초 관찰에도 **무한 블록**, 설정 시 `SocketTimeoutException`으로 3초에 복귀.

## 수정
타임아웃을 설정한 요청 팩토리로 `RestTemplate`을 구성해 재사용합니다(호출마다 새 인스턴스 생성도 제거).
```java
private static final RestTemplate REST_TEMPLATE = createRestTemplate();
private static RestTemplate createRestTemplate() {
    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
    factory.setConnectTimeout(5000);
    factory.setReadTimeout(30000);
    return new RestTemplate(factory);
}
```

## 검증
- 소켓 레벨 재현 하네스로 무한 블록 → 타임아웃 복귀 확인.
- `javac` 컴파일 통과. 공개 API·호출부 시그니처 불변(+19 / −4).

## 영향 범위
- 예외 처리 경로 동일(`RestClientException` → `SpException`). 타임아웃 값(5s/30s)은 보수적 기본값이며 필요 시 조정 가능합니다.