### PR TITLE
fix(EgovFileUtility): 파일 확장자 허용목록 비교 Locale 독립화 (터키어 등서 정상 파일 거부 방지)

### DIFF
--- a/EgovBoard/src/main/java/egovframework/com/cop/brd/util/EgovFileUtility.java
+++ b/EgovBoard/src/main/java/egovframework/com/cop/brd/util/EgovFileUtility.java
@@ -16,6 +16,7 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
@@ -113,7 +114,9 @@ public class EgovFileUtility {
         if (dot < 0 || dot == fileName.length() - 1) {
             return false;
         }
-        String extension = fileName.substring(dot + 1).toLowerCase();
+        // 로케일 독립: 터키어 등 일부 로케일에서 대소문자 규칙 차이로
+        // 허용 확장자(예: GIF) 비교가 어긋나 정상 파일이 거부되는 문제 방지
+        String extension = fileName.substring(dot + 1).toLowerCase(Locale.ROOT);
         return Arrays.asList(allowedExtensions.split(",")).contains(extension);
     }
 


### PR DESCRIPTION
## 요약
파일 업로드 확장자 허용목록 검사가 확장자를 **Locale 미지정 `toLowerCase()`** 로 소문자화해 비교합니다. 터키어 등 일부 로케일에서 대소문자 규칙 차이로 **정상 파일(예: `.GIF`)이 거부**됩니다(java:S1449 / 로케일 의존 케이스 변환).

## 문제 (재현)
`EgovFileUtility.validFileExtension`:
```java
String extension = fileName.substring(dot + 1).toLowerCase();
return Arrays.asList(allowedExtensions.split(",")).contains(extension);
```
터키어 로케일에서 `"GIF".toLowerCase()` = `"gıf"`(점 없는 ı) → 허용목록의 `"gif"` 와 불일치 → **정상 GIF 업로드 거부**.

- 실증(JDK17, 허용목록 `jpg,gif,png,pdf`):
  - `photo.GIF`: **기존** EN 허용=true, **TR 허용=false(거부)** / **수정** TR 허용=true
  - `doc.PDF`·`img.PNG`: I 없어 무영향(양쪽 동일)

## 수정
로케일 독립적인 `Locale.ROOT` 를 명시합니다.
```java
String extension = fileName.substring(dot + 1).toLowerCase(Locale.ROOT);
```
`import java.util.Locale;` 추가 + 호출 1곳 수정(+4/−1).

## 영향 범위
- 허용목록 비교의 로케일 의존성만 제거. 서버 기본 로케일과 무관하게 동일 동작. 정상(ASCII) 로케일 동작 불변, 공개 시그니처 불변.
- 서버 기본 로케일이 터키어/아제르바이잔어 등인 환경에서 특히 유효합니다.