### PR TITLE
build(EgovAuthor): BOM 기반 의존성 버전 관리 정리

### DIFF
--- a/EgovAuthor/pom.xml
+++ b/EgovAuthor/pom.xml
@@ -4,7 +4,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>egovframework</groupId>
     <artifactId>EgovAuthor</artifactId>
-    <version>5.0.0</version>
     <name>EgovAuthor</name>
     <url>https://www.egovframe.go.kr</url>
 
@@ -24,21 +23,16 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
-        <mysql.connector.version>8.4.0</mysql.connector.version>
+        <mysql.version>8.4.0</mysql.version>
         <commons-configuration2.version>2.11.0</commons-configuration2.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-io.version>2.20.0</commons-io.version>
         <commons-text.version>1.14.0</commons-text.version>
-        <netty-resolver.version>4.2.10.Final</netty-resolver.version>
+        <netty.version>4.2.10.Final</netty.version>
         <guava.version>33.0.0-jre</guava.version>
         <httpclient.version>4.5.14</httpclient.version>
         <logback.version>1.5.32</logback.version>
         <thoughtworks.xstream.version>1.4.21</thoughtworks.xstream.version>
-        <log4j2.version>2.25.3</log4j2.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <tomcat-embed.version>10.1.52</tomcat-embed.version>
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <tomcat.version>10.1.52</tomcat.version>
         <apache.maven.compiler.plugin>3.14.1</apache.maven.compiler.plugin>
     </properties>
 
@@ -101,7 +95,6 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>com.querydsl</groupId>
@@ -163,12 +156,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -178,7 +169,6 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>${netty-resolver.version}</version>
             <classifier>osx-aarch_64</classifier>
             <scope>runtime</scope>
         </dependency>
@@ -209,12 +199,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <!-- CVE-2024-47072: spring-cloud-starter-netflix-eureka-client에서 주입되는 xstream 1.4.20 취약점 보완용 직접 주입 -->
         <dependency>
@@ -226,76 +214,62 @@
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
-            <version>${netty-resolver.version}</version>
         </dependency>
 	<dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-common</artifactId>
-            <version>${netty-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-buffer</artifactId>
-            <version>${netty-resolver.version}</version>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-transport</artifactId>
-            <version>${netty-resolver.version}</version>
         </dependency>
         <!-- Logging -->
         <!-- CVE-2025-68161: 취약점 보완용 업데이트 -->
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <!-- CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-annotations-api</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <!-- CVE-2025-48734: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

EgovAuthor의 의존성 버전이 상위 POM 및 Spring Boot BOM과 중복 선언되어 발생하는 Maven 관리 버전 재정의 경고를 해소하고, 의존성 버전 관리 방식을 일관되게 정리합니다.

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

- 부모 POM과 동일한 프로젝트 버전 선언을 제거했습니다.
- 상위 POM과 값이 같은 중복 속성을 제거했습니다.
  - `java.version`
  - `commons-lang3.version`
  - `log4j2.version`
  - `slf4j.version`
  - `commons-beanutils.version`
- BOM 관리 버전과 동일한 의존성별 `<version>` 선언을 제거했습니다.
- MySQL, Netty, Tomcat 버전을 Spring Boot BOM 표준 속성으로 재정의했습니다.
  - `mysql.version`: `8.4.0`
  - `netty.version`: `4.2.10.Final`
  - `tomcat.version`: `10.1.52`
- MySQL, Netty, Tomcat 의존성의 개별 `<version>` 선언을 제거했습니다.
- 기존 보안 보완 버전을 유지하면서 `OverridingOfManagedDependency` 경고가 발생하지 않도록 변경했습니다.
- BOM을 통해 모든 Netty 및 Tomcat 모듈에 동일한 계열 버전이 적용되도록 정렬했습니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [x] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

`mvn -f EgovAuthor/pom.xml test` 실행 결과 `BUILD SUCCESS`를 확인했습니다.  
현재 EgovAuthor에는 실행할 테스트 소스가 없습니다.

추가 검증 결과:

- MySQL `8.4.0` 적용 확인
- 전체 Netty 모듈 `4.2.10.Final` 적용 확인
- 전체 Tomcat 모듈 `10.1.52` 적용 확인
- `git diff --check` 이상 없음

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

Maven POM 변경으로 브라우저 테스트 대상이 아닙니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

https://youtu.be/Wp0aHYneWEw

