### PR TITLE
build(EgovCmmnCode): 부모 POM 버전 관리 중복 제거

### DIFF
--- a/EgovCmmnCode/pom.xml
+++ b/EgovCmmnCode/pom.xml
@@ -4,7 +4,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>egovframework</groupId>
     <artifactId>EgovCmmnCode</artifactId>
-    <version>5.0.0</version>
     <name>EgovCmmnCode</name>
     <url>https://www.egovframe.go.kr</url>
 
@@ -24,20 +23,15 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
-        <mysql.connector.version>8.4.0</mysql.connector.version>
+        <mysql.version>8.4.0</mysql.version>
         <commons-configuration2.version>2.11.0</commons-configuration2.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-io.version>2.20.0</commons-io.version>
         <commons-text.version>1.14.0</commons-text.version>
         <guava.version>33.0.0-jre</guava.version>
         <httpclient.version>4.5.14</httpclient.version>
         <logback.version>1.5.32</logback.version>
         <thoughtworks.xstream.version>1.4.21</thoughtworks.xstream.version>
-        <log4j2.version>2.25.3</log4j2.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <tomcat-embed.version>10.1.52</tomcat-embed.version>
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
+        <tomcat.version>10.1.52</tomcat.version>
     </properties>
 
     <repositories>
@@ -99,7 +93,6 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>org.projectlombok</groupId>
@@ -148,12 +141,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -187,12 +178,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <!-- CVE-2024-47072: spring-cloud-starter-netflix-eureka-client에서 주입되는 xstream 1.4.20 취약점 보완용 직접 주입 -->
         <dependency>
@@ -205,54 +194,44 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <!-- CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-annotations-api</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <!-- CVE-2025-48734: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

EgovCmmnCode/pom.xml

- 부모와 중복되는 프로젝트 버전 선언 제거
- java, commons-lang3, log4j2, slf4j, commons-beanutils 중복 속성 제거
- mysql.connector.version을 부모 BOM 표준 mysql.version으로 변경
- tomcat-embed.version을 부모 BOM 표준 tomcat.version으로 변경
- 부모가 관리하는 15개 의존성의 개별 version 선언 제거
- MySQL, Commons IO, Logback, Tomcat의 실제 버전 재정의 유지
- 최종 해석되는 의존성 버전과 Maven 빌드 성공 여부 확인

### 속성 변경

항목 | Spring Boot BOM 3.5.6 | eGovFrame 부모 POM 5.0.0 | 기존 pom.xml | 수정된 pom.xml | 결과
-- | -- | -- | -- | -- | --
프로젝트 버전 | — | 5.0.0 | <version>5.0.0</version> | 선언 제거 | 부모의 5.0.0 상속
java.version | 17¹ | 17 | 17 | 선언 제거 | 부모의 17 상속
mysql.version | 9.4.0 | 9.4.0 상속 | mysql.connector.version=8.4.0 | mysql.version=8.4.0 | BOM 표준 속성으로 8.4.0 재정의
commons-lang3.version | 3.17.0 | 3.18.0 | 3.18.0 | 선언 제거 | eGovFrame 부모의 3.18.0 상속
commons-io.version | 관리 안 함 | 2.18.0 | 2.20.0 | 2.20.0 유지 | 부모와 다른 버전 재정의
logback.version | 1.5.18 | 1.5.18 상속 | 1.5.32 | 1.5.32 유지 | 부모와 다른 버전 재정의
log4j2.version | 2.24.3 | 2.25.3 | 2.25.3 | 선언 제거 | eGovFrame 부모의 2.25.3 상속
slf4j.version | 2.0.17 | 2.0.17 | 2.0.17 | 선언 제거 | 부모의 2.0.17 상속
tomcat.version | 10.1.46 | 10.1.46 상속 | tomcat-embed.version=10.1.52 | tomcat.version=10.1.52 | BOM 표준 속성으로 10.1.52 재정의
commons-beanutils.version | 관리 안 함 | 1.11.0 | 1.11.0 | 선언 제거 | eGovFrame 부모의 1.11.0 상속

### 의존성 변경

의존성 | Spring Boot BOM | eGovFrame 부모 POM | 수정된 pom.xml | 최종 버전
-- | -- | -- | -- | --
mysql-connector-j | ${mysql.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 8.4.0
commons-lang3 | ${commons-lang3.version} | 3.18.0으로 재정의 | 개별 <version> 제거 | 3.18.0
commons-io | 관리 안 함 | ${commons-io.version} | 개별 <version> 제거 | 2.20.0
logback-classic | ${logback.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 1.5.32
logback-core | ${logback.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 1.5.32
log4j-core | ${log4j2.version} | 2.25.3으로 재정의 | 개별 <version> 제거 | 2.25.3
log4j-slf4j2-impl | ${log4j2.version} | 2.25.3으로 재정의 | 개별 <version> 제거 | 2.25.3
jcl-over-slf4j | ${slf4j.version} | 2.0.17 유지 | 개별 <version> 제거 | 2.0.17
log4j-over-slf4j | ${slf4j.version} | 2.0.17 유지 | 개별 <version> 제거 | 2.0.17
tomcat-annotations-api | ${tomcat.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 10.1.52
tomcat-embed-core | ${tomcat.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 10.1.52
tomcat-embed-el | ${tomcat.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 10.1.52
tomcat-embed-jasper | ${tomcat.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 10.1.52
tomcat-embed-websocket | ${tomcat.version} | Spring Boot 관리 상속 | 개별 <version> 제거 | 10.1.52
commons-beanutils | 관리 안 함 | ${commons-beanutils.version} | 개별 <version> 제거 | 1.11.0

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 전
<img width="1920" height="1080" alt="화면 캡처 2026-07-26 130735" src="https://github.com/user-attachments/assets/369ef3da-bdad-490c-b29f-e951c5932ce7" />

테스트 후
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/fb35a6fe-cd4d-444a-8c31-2a843af5fa49" />

https://youtu.be/M9HVbvEvu9I
