### PR TITLE
fix(egovlogin): POM 의존성 버전 관리를 정리

### DIFF
--- a/EgovLogin/pom.xml
+++ b/EgovLogin/pom.xml
@@ -4,7 +4,6 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>egovframework</groupId>
     <artifactId>EgovLogin</artifactId>
-    <version>5.0.0</version>
     <name>EgovLogin</name>
     <url>https://www.egovframe.go.kr</url>
 
@@ -24,10 +23,8 @@
     </parent>
 
     <properties>
-        <java.version>17</java.version>
-        <mysql.connector.version>8.4.0</mysql.connector.version>
+        <mysql.version>8.4.0</mysql.version>
         <commons-configuration2.version>2.11.0</commons-configuration2.version>
-        <commons-lang3.version>3.18.0</commons-lang3.version>
         <commons-io.version>2.20.0</commons-io.version>
         <commons-text.version>1.14.0</commons-text.version>
         <jwtt.version>0.12.6</jwtt.version>
@@ -36,11 +33,8 @@
         <httpclient.version>4.5.14</httpclient.version>
         <logback.version>1.5.32</logback.version>
         <thoughtworks.xstream.version>1.4.21</thoughtworks.xstream.version>
-        <log4j2.version>2.25.3</log4j2.version>
-        <slf4j.version>2.0.17</slf4j.version>
-        <tomcat-embed.version>10.1.52</tomcat-embed.version>
-        <commons-beanutils.version>1.11.0</commons-beanutils.version>
-        <apache.maven.compiler.plugin>3.14.1</apache.maven.compiler.plugin>
+        <tomcat.version>10.1.52</tomcat.version>
+        <maven-compiler-plugin.version>3.14.1</maven-compiler-plugin.version>
     </properties>
 
     <repositories>
@@ -102,7 +96,6 @@
         <dependency>
             <groupId>com.mysql</groupId>
             <artifactId>mysql-connector-j</artifactId>
-            <version>${mysql.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -188,12 +181,10 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>${commons-lang3.version}</version>
         </dependency>
         <dependency>
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
-            <version>${commons-io.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -227,12 +218,10 @@
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-classic</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <dependency>
             <groupId>ch.qos.logback</groupId>
             <artifactId>logback-core</artifactId>
-            <version>${logback.version}</version>
         </dependency>
         <!-- CVE-2024-47072: spring-cloud-starter-netflix-eureka-client에서 주입되는 xstream 1.4.20 취약점 보완용 직접 주입 -->
         <dependency>
@@ -245,54 +234,44 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j2-impl</artifactId>
-            <version>${log4j2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jcl-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>log4j-over-slf4j</artifactId>
-            <version>${slf4j.version}</version>
         </dependency>
         <!-- CVE-2025-66614/CVE-2026-24734/CVE-2026-24733: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>org.apache.tomcat</groupId>
             <artifactId>tomcat-annotations-api</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-core</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-el</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-jasper</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <dependency>
             <groupId>org.apache.tomcat.embed</groupId>
             <artifactId>tomcat-embed-websocket</artifactId>
-            <version>${tomcat-embed.version}</version>
         </dependency>
         <!-- CVE-2025-48734: 보안취약점 보완용 직접 주입 -->
         <dependency>
             <groupId>commons-beanutils</groupId>
             <artifactId>commons-beanutils</artifactId>
-            <version>${commons-beanutils.version}</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
## 수정 사유 Reason for modification

소스를 수정한 사유가 무엇인지 체크해 주세요. Please check the reason you modified the source. ([X] X는 대문자여야 합니다.)

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

## 수정된 소스 내용 Modified source

검토자를 위해 수정된 소스 내용을 설명해 주세요. Please describe the modified source for reviewers.

###  개요

`EgovLogin/pom.xml`의 중복 버전 선언과 Maven 관리 버전 재정의 경고를 정리합니다.

Spring Boot BOM과 eGovFrame 부모 POM이 제공하는 의존성 관리를 활용하면서 기존 보안 상향 버전과 실제 의존성 버전은 유지했습니다.

###  변경 내용

| 구분 | 변경 전 | 변경 후 |
|---|---|---|
| 프로젝트 버전 | 부모와 동일한 `5.0.0` 직접 선언 | 부모 POM에서 상속 |
| 부모 제공 속성 | 동일한 값을 자식 POM에서 재선언 | 중복 속성 제거 |
| MySQL 속성 | `mysql.connector.version` | Spring Boot 표준 `mysql.version` |
| Tomcat 속성 | `tomcat-embed.version` | Spring Boot 표준 `tomcat.version` |
| Maven Compiler Plugin | `apache.maven.compiler.plugin` | Spring Boot 표준 `maven-compiler-plugin.version` |
| 관리 의존성 버전 | 각 의존성에 `<version>` 직접 선언 | BOM 및 부모 POM의 dependency management 사용 |

###  제거한 중복 속성

| 속성 | 유지되는 버전 | 제공 위치 |
|---|---:|---|
| `java.version` | 17 | eGovFrame 부모 POM |
| `commons-lang3.version` | 3.18.0 | eGovFrame 부모 POM |
| `log4j2.version` | 2.25.3 | eGovFrame 부모 POM |
| `slf4j.version` | 2.0.17 | eGovFrame 부모 POM |
| `commons-beanutils.version` | 1.11.0 | eGovFrame 부모 POM |

###  직접 버전 선언을 제거한 의존성

| 분류 | 의존성 |
|---|---|
| Database | `mysql-connector-j` |
| Apache Commons | `commons-lang3`, `commons-io`, `commons-beanutils` |
| Logback | `logback-classic`, `logback-core` |
| Log4j | `log4j-core`, `log4j-slf4j2-impl` |
| SLF4J | `jcl-over-slf4j`, `log4j-over-slf4j` |
| Tomcat | `tomcat-annotations-api`, `tomcat-embed-core`, `tomcat-embed-el`, `tomcat-embed-jasper`, `tomcat-embed-websocket` |

###  보안 상향 버전 유지

| 구성요소 | 유지 버전 |
|---|---:|
| MySQL Connector/J | 8.4.0 |
| Commons IO | 2.20.0 |
| Logback | 1.5.32 |
| Log4j 2 | 2.25.3 |
| SLF4J | 2.0.17 |
| Tomcat | 10.1.52 |
| Commons BeanUtils | 1.11.0 |

###  기대 효과

- Maven 및 Language Server의 관리 버전 재정의 경고 해소
- Spring Boot BOM 표준 속성과의 일관성 확보
- 부모 POM과 중복되는 설정 제거
- 의존성 버전 관리 지점 단일화
- 기존 보안 상향 버전 유지

###  검증

- JDK: `17.0.17`
- Maven: `3.9.9`
- `mvn validate`: 성공
- `mvn test`: 성공
- 수정 전후 effective POM 직접 의존성: 43개
- 수정 전후 실제 의존성 버전 차이: 0건
- `git diff --check`: 이상 없음

> 컴파일 과정에서 기존 `EgovLoginManageController.java`의 UTF-8 문자 변환 진단이 출력됐지만 Maven 빌드 결과는 `BUILD SUCCESS`입니다.

## JUnit 테스트 JUnit tests

테스트를 완료하셨으면 다음 항목에 [대문자X]로 표시해 주세요. When you're done testing, check the following items.

- [ ] JUnit 테스트 JUnit tests
- [ ] 수동 테스트 Manual testing

## 테스트 브라우저 Test Browser

테스트를 진행한 브라우저를 선택해 주세요. Please select the browser(s) you ran the test on. (다중 선택 가능 you can select multiple) [X] X는 대문자여야 합니다.

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

테스트 전과 후의 스크린샷 또는 캡처 영상을 이곳에 첨부해 주세요. Please attach screenshots or video captures of your before and after tests here.

테스트 전
<img width="1920" height="1080" alt="화면 캡처 2026-07-27 084527" src="https://github.com/user-attachments/assets/87f00eeb-2fe4-49ab-a0a6-6a93b2823f96" />

테스트 후
<img width="1920" height="1080" alt="image" src="https://github.com/user-attachments/assets/0685cb7c-9b0e-4fb6-896e-cf15d7086c4a" />

https://youtu.be/JDS1IC0SHDQ
