### PR TITLE
docs(readme): 구동 대상 명칭을 EurekaServer로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@
  
 ## 프로젝트 구동 방법
 0. docker-compose/mysql 실행 `docker-compose up -d`
-1. EurekaService 실행
+1. EurekaServer 실행
 2. ConfigServer
    - `ConfigServer/src/main/resources/config/application-local.yml`
    - DB, Token 설정 확인


### PR DESCRIPTION
## 수정 사유 Reason for modification

- [ ] 버그수정 Bug fixes
- [ ] 기능개선 Enhancements
- [ ] 기능추가 Adding features
- [x] 기타 Others

README의 프로젝트 구동 순서에 기재된 `EurekaService`가 실제 Maven 모듈명인
`EurekaServer`와 일치하지 않아 문서 표기를 수정합니다.

## 수정된 소스 내용 Modified source

- `README.md`의 프로젝트 구동 순서에서 `EurekaService`를 `EurekaServer`로 변경했습니다.
- 저장소의 실제 모듈명 및 README 프로젝트 구성도와 표기를 일치시켰습니다.
- 애플리케이션 코드, 설정, API 동작에는 변경이 없습니다.

## JUnit 테스트 JUnit tests

- [ ] JUnit 테스트 JUnit tests
- [x] 수동 테스트 Manual testing

문서만 변경되어 JUnit 테스트는 실행하지 않았습니다.
README의 프로젝트 구성 및 실제 최상위 모듈 디렉터리가 `EurekaServer`임을 확인했습니다.

## 테스트 브라우저 Test Browser

- [ ] Chrome
- [ ] Firefox
- [ ] Edge
- [ ] Safari
- [ ] Opera
- [ ] Internet Explorer
- [ ] 기타 Others

브라우저 테스트가 필요하지 않은 문서 변경입니다.

## 테스트 스크린샷 또는 캡처 영상 Test screenshots or captured video

해당 없음